### PR TITLE
Commit Event to db before writing EventAgent

### DIFF
--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -75,6 +75,8 @@ def create_event_objects(fs_entry, file_id):
     for premis_event in fs_entry.get_premis_events():
         event = _extract_event_detail(premis_event, file_id)
         db.session.add(event)
+        db.session.commit()
+
         for event_relationship in _create_event_agent_relationship(
             event.id, premis_event.linking_agent_identifier
         ):


### PR DESCRIPTION
Connected to #70 

Events were previously missing from `EventAgent` objects because `event.id` was being passed as a parameter to `_create_event_agent_relationship` before the event was committed to database (and thus before it had a primary key). This fix commits the event to the database before moving on to writing `EventAgent`s.