### PR TITLE
Add "AIPs by file format" and "AIPs by PUID" reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ config.pyc
 aipscan.db
 celerytasks.db
 AIPscan/Aggregator/downloads/
+.tox/

--- a/AIPscan/API/namespace_data.py
+++ b/AIPscan/API/namespace_data.py
@@ -6,11 +6,18 @@ Return 'unkempt' data from AIPscan so that it can be filtered, cut, and
 remixed as the caller desires. Data is 'unkempt' not raw. No data is
 raw. No data is without bias.
 """
-from distutils.util import strtobool
 
 from flask import request
 from flask_restx import Namespace, Resource
+
+from AIPscan.helpers import parse_bool
 from AIPscan.Data import data
+
+FILE_FORMAT_FIELD = "file_format"
+FILE_TYPE_FIELD = "file_type"
+LIMIT_FIELD = "limit"
+ORIGINAL_FILES_FIELD = "original_files"
+PUID_FIELD = "puid"
 
 api = Namespace("data", description="Retrieve data from AIPscan to shape as you desire")
 
@@ -22,19 +29,12 @@ data = api.model('Data', {
 """
 
 
-def parse_bool(val, default=True):
-    try:
-        return bool(strtobool(val))
-    except (ValueError, AttributeError):
-        return default
-
-
 @api.route("/aip-overview/<storage_service_id>")
 class FMTList(Resource):
     @api.doc(
         "list_formats",
         params={
-            "original_files": {
+            ORIGINAL_FILES_FIELD: {
                 "description": "Return data for original files or copies",
                 "in": "query",
                 "type": "bool",
@@ -43,10 +43,7 @@ class FMTList(Resource):
     )
     def get(self, storage_service_id):
         """AIP overview One"""
-        try:
-            original_files = parse_bool(request.args.get("original_files"), True)
-        except TypeError:
-            pass
+        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
         aip_data = data.aip_overview(
             storage_service_id=storage_service_id, original_files=original_files
         )
@@ -58,8 +55,8 @@ class AIPList(Resource):
     @api.doc(
         "list_formats",
         params={
-            "original_files": {
-                "description": "Return data for original files or copies",
+            ORIGINAL_FILES_FIELD: {
+                "description": "Return data for original files or preservation derivatives",
                 "in": "query",
                 "type": "bool",
             }
@@ -67,10 +64,7 @@ class AIPList(Resource):
     )
     def get(self, storage_service_id):
         """AIP overview two"""
-        try:
-            original_files = parse_bool(request.args.get("original_files"), True)
-        except TypeError:
-            pass
+        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
         aip_data = data.aip_overview_two(
             storage_service_id=storage_service_id, original_files=original_files
         )
@@ -91,12 +85,12 @@ class LargestFileList(Resource):
     @api.doc(
         "list_formats",
         params={
-            "file_type": {
+            FILE_TYPE_FIELD: {
                 "description": "Optional file type filter (original or preservation)",
                 "in": "query",
                 "type": "str",
             },
-            "limit": {
+            LIMIT_FIELD: {
                 "description": "Number of results to return (default is 20)",
                 "in": "query",
                 "type": "int",
@@ -105,7 +99,7 @@ class LargestFileList(Resource):
     )
     def get(self, storage_service_id, file_type=None, limit=20):
         """Largest files"""
-        file_type = request.args.get("file_type", None)
+        file_type = request.args.get(FILE_TYPE_FIELD)
         try:
             limit = int(request.args.get("limit", 20))
         except ValueError:
@@ -114,3 +108,61 @@ class LargestFileList(Resource):
             storage_service_id=storage_service_id, file_type=file_type, limit=limit
         )
         return file_data
+
+
+@api.route("/aips-by-file-format/<storage_service_id>")
+class AIPsByFormatList(Resource):
+    @api.doc(
+        "list_aips_by_format",
+        params={
+            FILE_FORMAT_FIELD: {
+                "description": "File format name (must be exact match)",
+                "in": "query",
+                "type": "str",
+            },
+            ORIGINAL_FILES_FIELD: {
+                "description": "Return data for original files or preservation derivatives",
+                "in": "query",
+                "type": "bool",
+            },
+        },
+    )
+    def get(self, storage_service_id):
+        """AIPs containing given file format."""
+        file_format = request.args.get(FILE_FORMAT_FIELD, "")
+        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
+        aip_data = data.aips_by_file_format(
+            storage_service_id=storage_service_id,
+            file_format=file_format,
+            original_files=original_files,
+        )
+        return aip_data
+
+
+@api.route("/aips-by-puid/<storage_service_id>")
+class AIPsByPUIDList(Resource):
+    @api.doc(
+        "list_aips_by_puid",
+        params={
+            PUID_FIELD: {
+                "description": "PRONOM ID (PUID)",
+                "in": "query",
+                "type": "str",
+            },
+            ORIGINAL_FILES_FIELD: {
+                "description": "Return data for original files or preservation derivatives",
+                "in": "query",
+                "type": "bool",
+            },
+        },
+    )
+    def get(self, storage_service_id):
+        """AIPs containing given format version, specified by PUID."""
+        puid = request.args.get(PUID_FIELD, "")
+        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
+        aip_data = data.aips_by_puid(
+            storage_service_id=storage_service_id,
+            puid=puid,
+            original_files=original_files,
+        )
+        return aip_data

--- a/AIPscan/Aggregator/templates/edit_storage_service.html
+++ b/AIPscan/Aggregator/templates/edit_storage_service.html
@@ -29,6 +29,6 @@
 </table>
 <button type="submit" class="btn btn-success">Save</button>
 </form>
-<a href="{{ url_for('aggregator.ss') }}"><button class="btn btn-danger" style="margin-top: 10px;">Cancel</button></a>
+<a href="{{ url_for('aggregator.storage_services') }}"><button class="btn btn-danger" style="margin-top: 10px;">Cancel</button></a>
 
 {% endblock %}

--- a/AIPscan/Aggregator/views.py
+++ b/AIPscan/Aggregator/views.py
@@ -48,7 +48,7 @@ def ss_default():
         storage_service = StorageService.query.first()
         # there are no storage services defined at all
         if storage_service is None:
-            return redirect(url_for("aggregator.ss"))
+            return redirect(url_for("aggregator.storage_services"))
     mets_fetch_jobs = FetchJob.query.filter_by(
         storage_service_id=storage_service.id
     ).all()
@@ -71,7 +71,7 @@ def storage_service(id):
 
 
 @aggregator.route("/storage_services", methods=["GET"])
-def ss():
+def storage_services():
     storage_services = StorageService.query.all()
     return render_template("storage_services.html", storage_services=storage_services)
 
@@ -102,7 +102,7 @@ def edit_storage_service(id):
         storage_service.default = form.default.data
         db.session.commit()
         flash("Storage service {} updated".format(form.name.data))
-        return redirect(url_for("aggregator.ss"))
+        return redirect(url_for("aggregator.storage_services"))
     return render_template(
         "edit_storage_service.html", title="Storage Service", form=form
     )
@@ -124,7 +124,7 @@ def new_storage_service():
         db.session.add(ss)
         db.session.commit()
         flash("New storage service {} created".format(form.name.data))
-        return redirect(url_for("aggregator.ss"))
+        return redirect(url_for("aggregator.storage_services"))
     return render_template(
         "edit_storage_service.html", title="Storage Service", form=form
     )
@@ -140,7 +140,7 @@ def delete_storage_service(id):
     db.session.delete(storage_service)
     db.session.commit()
     flash("Storage service '{}' is deleted".format(storage_service.name))
-    return redirect(url_for("aggregator.ss"))
+    return redirect(url_for("aggregator.storage_services"))
 
 
 @aggregator.route("/new_fetch_job/<id>", methods=["POST"])

--- a/AIPscan/Data/tests/__init__.py
+++ b/AIPscan/Data/tests/__init__.py
@@ -1,0 +1,69 @@
+import datetime
+import uuid
+
+from AIPscan.models import StorageService, AIP
+
+
+class MockAIPsByFormatOrPUIDResult:
+    """Fixture for mocking AIPs by format/PUID results with labels."""
+
+    def __init__(self, id, name, uuid, file_count, total_size):
+        self.id = id
+        self.name = name
+        self.uuid = uuid
+        self.file_count = file_count
+        self.total_size = total_size
+
+
+MOCK_AIPS_BY_FORMAT_OR_PUID_QUERY_RESULTS = [
+    MockAIPsByFormatOrPUIDResult(
+        id=1,
+        name="aip0",
+        uuid="11111111-1111-1111-1111-111111111111",
+        file_count=5,
+        total_size=12345678,
+    ),
+    MockAIPsByFormatOrPUIDResult(
+        id=2,
+        name="aip1",
+        uuid="22222222-2222-2222-2222-222222222222",
+        file_count=3,
+        total_size=123456,
+    ),
+    MockAIPsByFormatOrPUIDResult(
+        id=5,
+        name="aip2",
+        uuid="33333333-3333-3333-3333-333333333333",
+        file_count=2,
+        total_size=12345,
+    ),
+    MockAIPsByFormatOrPUIDResult(
+        id=10,
+        name="aip3",
+        uuid="44444444-4444-4444-4444-444444444444",
+        file_count=1,
+        total_size=123,
+    ),
+]
+
+MOCK_STORAGE_SERVICE_ID = 1
+MOCK_STORAGE_SERVICE_NAME = "some name"
+MOCK_STORAGE_SERVICE = StorageService(
+    name=MOCK_STORAGE_SERVICE_NAME,
+    url="http://example.com",
+    user_name="test",
+    api_key="test",
+    download_limit=20,
+    download_offset=10,
+    default=False,
+)
+
+MOCK_AIP_NAME = "Test transfer"
+MOCK_AIP_UUID = str(uuid.uuid4())
+MOCK_AIP = AIP(
+    uuid=MOCK_AIP_UUID,
+    transfer_name=MOCK_AIP_NAME,
+    create_date=datetime.datetime.now(),
+    storage_service_id=MOCK_STORAGE_SERVICE_ID,
+    fetch_job_id=1,
+)

--- a/AIPscan/Data/tests/conftest.py
+++ b/AIPscan/Data/tests/conftest.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+"""This module defines shared Data blueprint pytest fixtures."""
+
+import datetime
+import pytest
+
+from AIPscan import db, create_app
+from AIPscan.models import StorageService, FetchJob, AIP, File, FileType
+
+
+TIFF_FILE_FORMAT = "Tagged Image File Format"
+TIFF_PUID = "fmt/353"
+
+ORIGINAL_FILE_SIZE = 1000
+PRESERVATION_FILE_SIZE = 2000
+
+
+@pytest.fixture
+def app_with_populated_files(scope="package"):
+    """Fixture with pre-populated data.
+
+    This fixture is used to create expected state which is then used to
+    test the Data.aips_by_file_format and Data.aips_by_puid endpoints.
+    """
+    app = create_app("test")
+    with app.app_context():
+        db.create_all()
+
+        storage_service = StorageService(
+            name="test storage service",
+            url="http://example.com",
+            user_name="test",
+            api_key="test",
+            download_limit=20,
+            download_offset=10,
+            default=True,
+        )
+        db.session.add(storage_service)
+        db.session.commit()
+
+        fetch_job = FetchJob(
+            total_packages=1,
+            total_aips=1,
+            total_deleted_aips=0,
+            download_start=datetime.datetime.now(),
+            download_end=datetime.datetime.now(),
+            download_directory="/some/dir",
+            storage_service_id=storage_service.id,
+        )
+        db.session.add(fetch_job)
+        db.session.commit()
+
+        aip = AIP(
+            uuid="111111111111-1111-1111-11111111",
+            transfer_name="test aip",
+            create_date=datetime.datetime.now(),
+            storage_service_id=storage_service.id,
+            fetch_job_id=fetch_job.id,
+        )
+        db.session.add(aip)
+        db.session.commit()
+
+        original_file = File(
+            name="original.tif",
+            filepath="/path/to/original.tif",
+            uuid="111111111111-1111-1111-11111111",
+            file_type=FileType.original,
+            size=ORIGINAL_FILE_SIZE,
+            date_created=datetime.datetime.now(),
+            puid=TIFF_PUID,
+            file_format=TIFF_FILE_FORMAT,
+            checksum_type="test",
+            checksum_value="test",
+            aip_id=1,
+        )
+        preservation_file = File(
+            name="preservation.tif",
+            filepath="/path/to/preservation.tif",
+            uuid="222222222222-2222-2222-22222222",
+            file_type=FileType.preservation,
+            size=PRESERVATION_FILE_SIZE,
+            date_created=datetime.datetime.now(),
+            puid=TIFF_PUID,
+            file_format=TIFF_FILE_FORMAT,
+            checksum_type="test",
+            checksum_value="test",
+            aip_id=1,
+        )
+        db.session.add(original_file)
+        db.session.add(preservation_file)
+        db.session.commit()
+
+        yield app
+
+        db.drop_all()

--- a/AIPscan/Data/tests/test_aips_by_format.py
+++ b/AIPscan/Data/tests/test_aips_by_format.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from AIPscan.Data import data
+from AIPscan.Data.tests import (
+    MOCK_AIPS_BY_FORMAT_OR_PUID_QUERY_RESULTS as MOCK_QUERY_RESULTS,
+    MOCK_STORAGE_SERVICE,
+    MOCK_STORAGE_SERVICE_ID,
+    MOCK_STORAGE_SERVICE_NAME,
+)
+from AIPscan.Data.tests.conftest import (
+    TIFF_FILE_FORMAT,
+    ORIGINAL_FILE_SIZE,
+    PRESERVATION_FILE_SIZE,
+)
+
+
+@pytest.mark.parametrize(
+    "query_results, results_count",
+    [
+        # Empty result set, count is 0.
+        ([], 0),
+        # Test the return of complete result set, count is the length
+        # of all results.
+        (MOCK_QUERY_RESULTS, len(MOCK_QUERY_RESULTS)),
+        # Test the return of only the first two results, count is 2.
+        (MOCK_QUERY_RESULTS[:2], 2),
+    ],
+)
+def test_aips_by_file_format(app_instance, mocker, query_results, results_count):
+    """Test that results match high-level expectations."""
+    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query.return_value = query_results
+
+    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
+
+    report = data.aips_by_file_format(MOCK_STORAGE_SERVICE_ID, "Some file format")
+    assert report[data.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
+    assert len(report[data.FIELD_AIPS]) == results_count
+
+
+@pytest.mark.parametrize(
+    "test_aip", [mock_result for mock_result in MOCK_QUERY_RESULTS]
+)
+def test_aips_by_file_format_aip_elements(app_instance, mocker, test_aip):
+    """Test that structure of AIP data matches expectations."""
+    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query.return_value = [test_aip]
+
+    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
+
+    report = data.aips_by_file_format(MOCK_STORAGE_SERVICE_ID, "Some file format")
+    report_aip = report[data.FIELD_AIPS][0]
+
+    assert test_aip.id == report_aip.get("id")
+    assert test_aip.name == report_aip.get(data.FIELD_AIP_NAME)
+    assert test_aip.uuid == report_aip.get(data.FIELD_UUID)
+    assert test_aip.file_count == report_aip.get(data.FIELD_COUNT)
+    assert test_aip.total_size == report_aip.get(data.FIELD_SIZE)
+
+
+@pytest.mark.parametrize(
+    "format_name, original_files, aip_count, total_file_count, total_file_size",
+    [
+        # Original format in test data should be included in results.
+        (TIFF_FILE_FORMAT, True, 1, 1, ORIGINAL_FILE_SIZE),
+        # Original format not in test data should not be included in
+        # results.
+        ("Maya Binary", True, 0, 0, 0),
+        # Preservation format in test data should be included in
+        # results.
+        (TIFF_FILE_FORMAT, False, 1, 1, PRESERVATION_FILE_SIZE),
+        # Non-existent preservation format not present in test data
+        # should not be included in results.
+        ("PDF/Z", False, 0, 0, 0),
+        # Passing a None value for original_files returns original
+        # files.
+        (TIFF_FILE_FORMAT, None, 1, 1, ORIGINAL_FILE_SIZE),
+        # Passing an incorrect value for original_files returns
+        # original files.
+        (TIFF_FILE_FORMAT, "invalid", 1, 1, ORIGINAL_FILE_SIZE),
+    ],
+)
+def test_aips_by_file_format_contents(
+    app_with_populated_files,
+    format_name,
+    original_files,
+    aip_count,
+    total_file_count,
+    total_file_size,
+):
+    """Test that content of response matches expectations.
+
+    This integration test uses a pre-populated fixture to verify that
+    the database access layer of our endpoint returns what we expect.
+    """
+    results = data.aips_by_file_format(
+        storage_service_id=1, file_format=format_name, original_files=original_files
+    )
+    aips = results[data.FIELD_AIPS]
+    assert len(aips) == aip_count
+    assert sum(aip[data.FIELD_COUNT] for aip in aips) == total_file_count
+    assert sum(aip[data.FIELD_SIZE] for aip in aips) == total_file_size

--- a/AIPscan/Data/tests/test_aips_by_puid.py
+++ b/AIPscan/Data/tests/test_aips_by_puid.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+
+from AIPscan.Data import data
+from AIPscan.Data.tests import (
+    MOCK_AIPS_BY_FORMAT_OR_PUID_QUERY_RESULTS as MOCK_QUERY_RESULTS,
+    MOCK_STORAGE_SERVICE,
+    MOCK_STORAGE_SERVICE_ID,
+    MOCK_STORAGE_SERVICE_NAME,
+)
+from AIPscan.Data.tests.conftest import (
+    TIFF_PUID,
+    ORIGINAL_FILE_SIZE,
+    PRESERVATION_FILE_SIZE,
+)
+
+
+@pytest.mark.parametrize(
+    "query_results, results_count",
+    [
+        # Empty result set, count is 0.
+        ([], 0),
+        # Test the return of complete result set, count is the length
+        # of all results.
+        (MOCK_QUERY_RESULTS, len(MOCK_QUERY_RESULTS)),
+        # Test the return of only the first two results, count is 2.
+        (MOCK_QUERY_RESULTS[:2], 2),
+    ],
+)
+def test_aips_by_puid(app_instance, mocker, query_results, results_count):
+    """Test that results match high-level expectations."""
+    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query.return_value = query_results
+
+    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
+
+    report = data.aips_by_puid(MOCK_STORAGE_SERVICE_ID, "fmt/###")
+    assert report[data.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
+    assert len(report[data.FIELD_AIPS]) == results_count
+
+
+@pytest.mark.parametrize(
+    "test_aip", [mock_result for mock_result in MOCK_QUERY_RESULTS]
+)
+def test_aips_by_puid_aip_elements(app_instance, mocker, test_aip):
+    """Test that structure of AIP data matches expectations."""
+    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query.return_value = [test_aip]
+
+    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
+
+    report = data.aips_by_puid(MOCK_STORAGE_SERVICE_ID, "fmt/###")
+    report_aip = report[data.FIELD_AIPS][0]
+
+    assert test_aip.id == report_aip.get("id")
+    assert test_aip.name == report_aip.get(data.FIELD_AIP_NAME)
+    assert test_aip.uuid == report_aip.get(data.FIELD_UUID)
+    assert test_aip.file_count == report_aip.get(data.FIELD_COUNT)
+    assert test_aip.total_size == report_aip.get(data.FIELD_SIZE)
+
+
+@pytest.mark.parametrize(
+    "puid, original_files, aip_count, total_file_count, total_file_size",
+    [
+        # Original format in test data should be included in results.
+        (TIFF_PUID, True, 1, 1, ORIGINAL_FILE_SIZE),
+        # Original format not in test data should not be included in
+        # results.
+        ("fmt/1", True, 0, 0, 0),
+        # Preservation format in test data should be included in
+        # results.
+        (TIFF_PUID, False, 1, 1, PRESERVATION_FILE_SIZE),
+        # Non-existent preservation format not present in test data
+        # should not be included in results.
+        ("x-fmt/999999", False, 0, 0, 0),
+        # Passing a None value for original_files returns original
+        # files.
+        (TIFF_PUID, None, 1, 1, ORIGINAL_FILE_SIZE),
+        # Passing an incorrect value for original_files returns
+        # original files.
+        (TIFF_PUID, "invalid", 1, 1, ORIGINAL_FILE_SIZE),
+    ],
+)
+def test_aips_by_file_format_contents(
+    app_with_populated_files,
+    puid,
+    original_files,
+    aip_count,
+    total_file_count,
+    total_file_size,
+):
+    """Test that content of response matches expectations.
+
+    This integration test uses a pre-populated fixture to verify that
+    the database access layer of our endpoint returns what we expect.
+    """
+    results = data.aips_by_puid(
+        storage_service_id=1, puid=puid, original_files=original_files
+    )
+    aips = results[data.FIELD_AIPS]
+    assert len(aips) == aip_count
+    assert sum(aip[data.FIELD_COUNT] for aip in aips) == total_file_count
+    assert sum(aip[data.FIELD_SIZE] for aip in aips) == total_file_size

--- a/AIPscan/Data/tests/test_largest_files.py
+++ b/AIPscan/Data/tests/test_largest_files.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
-
 import datetime
 import pytest
 import uuid
 
 from AIPscan.Data import data
-from AIPscan.models import AIP, File, FileType, StorageService
+from AIPscan.Data.tests import (
+    MOCK_AIP,
+    MOCK_AIP_NAME,
+    MOCK_AIP_UUID,
+    MOCK_STORAGE_SERVICE,
+    MOCK_STORAGE_SERVICE_ID,
+    MOCK_STORAGE_SERVICE_NAME,
+)
+from AIPscan.models import File, FileType
+
 
 TEST_FILES = [
     File(
@@ -49,28 +57,6 @@ TEST_FILES = [
     ),
 ]
 
-MOCK_STORAGE_SERVICE_ID = 1
-MOCK_STORAGE_SERVICE_NAME = "some name"
-TEST_STORAGE_SERVICE = StorageService(
-    name=MOCK_STORAGE_SERVICE_NAME,
-    url="http://example.com",
-    user_name="test",
-    api_key="test",
-    download_limit=20,
-    download_offset=10,
-    default=False,
-)
-
-MOCK_AIP_NAME = "Test transfer"
-MOCK_AIP_UUID = uuid.uuid4()
-TEST_AIP = AIP(
-    uuid=MOCK_AIP_UUID,
-    transfer_name=MOCK_AIP_NAME,
-    create_date=datetime.datetime.now(),
-    storage_service_id=MOCK_STORAGE_SERVICE_ID,
-    fetch_job_id=1,
-)
-
 
 @pytest.mark.parametrize(
     "file_data, file_count", [([], 0), (TEST_FILES, 3), (TEST_FILES[:2], 2)]
@@ -82,10 +68,10 @@ def test_largest_files(app_instance, mocker, file_data, file_count):
     mock_query.return_value = file_data
 
     mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
-    mock_get_ss.return_value = TEST_STORAGE_SERVICE
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
     mock_get_aip = mocker.patch("sqlalchemy.orm.query.Query.get")
-    mock_get_aip.return_value = TEST_AIP
+    mock_get_aip.return_value = MOCK_AIP
 
     report = data.largest_files(MOCK_STORAGE_SERVICE_ID)
     report_files = report[data.FIELD_FILES]
@@ -110,10 +96,10 @@ def test_largest_files_elements(
     mock_query.return_value = [test_file]
 
     mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
-    mock_get_ss.return_value = TEST_STORAGE_SERVICE
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
     mock_get_aip = mocker.patch("sqlalchemy.orm.query.Query.get")
-    mock_get_aip.return_value = TEST_AIP
+    mock_get_aip.return_value = MOCK_AIP
 
     report = data.largest_files(MOCK_STORAGE_SERVICE_ID)
     report_file = report[data.FIELD_FILES][0]

--- a/AIPscan/Reporter/__init__.py
+++ b/AIPscan/Reporter/__init__.py
@@ -6,7 +6,18 @@ module, notably too the Blueprint itself.
 
 from flask import Blueprint
 
-from AIPscan.Reporter.helpers import translate_headers  # noqa: F401
+from AIPscan.Reporter.helpers import sort_puids, translate_headers  # noqa: F401
 
 
 reporter = Blueprint("reporter", __name__, template_folder="templates")
+
+request_params = {
+    "storage_service_id": "amss_id",
+    "file_format": "file_format",
+    "puid": "puid",
+    "original_files": "original_files",
+    "file_type": "file_type",
+    "limit": "limit",
+    "start_date": "start_date",
+    "end_date": "end_date",
+}

--- a/AIPscan/Reporter/helpers.py
+++ b/AIPscan/Reporter/helpers.py
@@ -2,8 +2,24 @@
 
 """Code shared across reporting modules but not outside of reporting.
 """
+from natsort import natsorted
 
 from AIPscan.Data import data
+
+
+def sort_puids(puids):
+    """Return PUIDs sorted in natural sorting order.
+
+    Python sorts strings containining integers in ASCII order - i.e.
+    ["fmt/1", "fmt/10", "fmt/2"]. Since this is different than what end
+    users expect, this helper uses the natsort library to reorder PUIDs
+    into natural sort order - i.e. ["fmt/1", "fmt/2", "fmt/10"].
+
+    :param puids: List of PUIDs
+
+    :returns: Sorted list of PUIDs
+    """
+    return natsorted(puids)
 
 
 def translate_headers(headers):

--- a/AIPscan/Reporter/report_aip_contents.py
+++ b/AIPscan/Reporter/report_aip_contents.py
@@ -4,13 +4,13 @@ from flask import render_template, request
 
 from AIPscan.Data import data
 from AIPscan.helpers import get_human_readable_file_size
-from AIPscan.Reporter import reporter, translate_headers
+from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
 @reporter.route("/aip_contents/", methods=["GET"])
 def aip_contents():
     """Return AIP contents organized by format."""
-    storage_service_id = request.args.get("amss_id")
+    storage_service_id = request.args.get(request_params["storage_service_id"])
     aip_data = data.aip_overview_two(storage_service_id=storage_service_id)
     FIELD_UUID = "UUID"
     headers = [

--- a/AIPscan/Reporter/report_aips_by_format.py
+++ b/AIPscan/Reporter/report_aips_by_format.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+
+from flask import render_template, request
+
+from AIPscan.helpers import parse_bool
+from AIPscan.Data import data
+from AIPscan.Reporter import reporter, translate_headers, request_params
+
+
+@reporter.route("/aips_by_file_format/", methods=["GET"])
+def aips_by_format():
+    """Return AIPs containing file format, sorted by count and total size."""
+    storage_service_id = request.args.get(request_params["storage_service_id"])
+    file_format = request.args.get(request_params["file_format"])
+    original_files = parse_bool(
+        request.args.get(request_params["original_files"], True)
+    )
+    aip_data = data.aips_by_file_format(
+        storage_service_id=storage_service_id,
+        file_format=file_format,
+        original_files=original_files,
+    )
+    headers = [data.FIELD_AIP_NAME, data.FIELD_UUID, data.FIELD_COUNT, data.FIELD_SIZE]
+    return render_template(
+        "report_aips_by_format.html",
+        storage_service_id=storage_service_id,
+        storage_service_name=aip_data.get(data.FIELD_STORAGE_NAME),
+        file_format=file_format,
+        original_files=original_files,
+        columns=translate_headers(headers),
+        aips=aip_data.get(data.FIELD_AIPS),
+    )

--- a/AIPscan/Reporter/report_aips_by_puid.py
+++ b/AIPscan/Reporter/report_aips_by_puid.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+from flask import render_template, request
+
+from AIPscan.helpers import parse_bool
+from AIPscan.models import File
+from AIPscan.Data import data
+from AIPscan.Reporter import reporter, translate_headers, request_params
+
+
+def get_format_string_from_puid(puid):
+    """Return file format and version info for a PUID or None
+
+    :param puid: PUID (str)
+
+    :returns: "File format (version)", "File Format", or None.
+    """
+    file_with_puid = File.query.filter_by(puid=puid).first()
+    if file_with_puid is None:
+        return None
+    try:
+        file_format = file_with_puid.file_format
+    except AttributeError:
+        return None
+    try:
+        format_version = file_with_puid.format_version
+    except AttributeError:
+        pass
+    if format_version:
+        return "{} ({})".format(file_format, format_version)
+    return file_format
+
+
+@reporter.route("/aips_by_puid/", methods=["GET"])
+def aips_by_puid():
+    """Return AIPs containing PUID, sorted by count and total size."""
+    storage_service_id = request.args.get(request_params["storage_service_id"])
+    puid = request.args.get(request_params["puid"])
+    original_files = parse_bool(
+        request.args.get(request_params["original_files"], True)
+    )
+    aip_data = data.aips_by_puid(
+        storage_service_id=storage_service_id, puid=puid, original_files=original_files
+    )
+    headers = [data.FIELD_AIP_NAME, data.FIELD_UUID, data.FIELD_COUNT, data.FIELD_SIZE]
+    return render_template(
+        "report_aips_by_puid.html",
+        storage_service_id=storage_service_id,
+        storage_service_name=aip_data.get(data.FIELD_STORAGE_NAME),
+        puid=puid,
+        file_format=get_format_string_from_puid(puid),
+        original_files=original_files,
+        columns=translate_headers(headers),
+        aips=aip_data.get(data.FIELD_AIPS),
+    )

--- a/AIPscan/Reporter/report_formats_count.py
+++ b/AIPscan/Reporter/report_formats_count.py
@@ -12,7 +12,7 @@ from flask import render_template, request
 
 from AIPscan.models import AIP, Event, File, FileType, StorageService
 from AIPscan.helpers import get_human_readable_file_size
-from AIPscan.Reporter import reporter
+from AIPscan.Reporter import reporter, request_params
 
 
 @reporter.route("/report_formats_count/", methods=["GET"])
@@ -20,15 +20,15 @@ def report_formats_count():
     """Report (tabular) on all file formats and their counts and size on
     disk across all AIPs in the storage service.
     """
-    start_date = request.args.get("startdate")
-    end_date = request.args.get("enddate")
+    start_date = request.args.get(request_params["start_date"])
+    end_date = request.args.get(request_params["end_date"])
     # make date range inclusive
     start = datetime.strptime(start_date, "%Y-%m-%d")
     end = datetime.strptime(end_date, "%Y-%m-%d")
     day_before = start - timedelta(days=1)
     day_after = end + timedelta(days=1)
 
-    storage_service_id = request.args.get("ssId")
+    storage_service_id = request.args.get(request_params["storage_service_id"])
     storage_service = StorageService.query.get(storage_service_id)
     aips = AIP.query.filter_by(storage_service_id=storage_service_id).all()
 
@@ -95,15 +95,15 @@ def report_formats_count():
 def chart_formats_count():
     """Report (pie chart) on all file formats and their counts and size
     on disk across all AIPs in the storage service."""
-    start_date = request.args.get("startdate")
-    end_date = request.args.get("enddate")
+    start_date = request.args.get(request_params["start_date"])
+    end_date = request.args.get(request_params["end_date"])
     # make date range inclusive
     start = datetime.strptime(start_date, "%Y-%m-%d")
     end = datetime.strptime(end_date, "%Y-%m-%d")
     day_before = start - timedelta(days=1)
     day_after = end + timedelta(days=1)
 
-    storage_service_id = request.args.get("ssId")
+    storage_service_id = request.args.get(request_params["storage_service_id"])
     storage_service = StorageService.query.get(storage_service_id)
     aips = AIP.query.filter_by(storage_service_id=storage_service_id).all()
 
@@ -154,15 +154,15 @@ def plot_formats_count():
     """Report (scatter) on all file formats and their counts and size on
     disk across all AIPs in the storage service.
     """
-    start_date = request.args.get("startdate")
-    end_date = request.args.get("enddate")
+    start_date = request.args.get(request_params["start_date"])
+    end_date = request.args.get(request_params["end_date"])
     # make date range inclusive
     start = datetime.strptime(start_date, "%Y-%m-%d")
     end = datetime.strptime(end_date, "%Y-%m-%d")
     day_before = start - timedelta(days=1)
     day_after = end + timedelta(days=1)
 
-    storage_service_id = request.args.get("ssId")
+    storage_service_id = request.args.get(request_params["storage_service_id"])
     storage_service = StorageService.query.get(storage_service_id)
     aips = AIP.query.filter_by(storage_service_id=storage_service_id).all()
 

--- a/AIPscan/Reporter/report_largest_files.py
+++ b/AIPscan/Reporter/report_largest_files.py
@@ -3,20 +3,19 @@
 from flask import render_template, request
 
 from AIPscan.Data import data
-from AIPscan.Reporter import reporter, translate_headers
+from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
 @reporter.route("/largest_files/", methods=["GET"])
 def largest_files():
     """Return largest files."""
-    storage_service_id = request.args.get("amss_id")
-    file_type = request.args.get("file_type")
+    storage_service_id = request.args.get(request_params["storage_service_id"])
+    file_type = request.args.get(request_params["file_type"])
     limit = 20
     try:
-        limit = int(request.args.get("limit", 20))
+        limit = int(request.args.get(request_params["limit"], 20))
     except ValueError:
         pass
-    # TODO: Make limit configurable - currently set to default of 20
     file_data = data.largest_files(
         storage_service_id=storage_service_id, file_type=file_type, limit=limit
     )

--- a/AIPscan/Reporter/report_originals_with_derivatives.py
+++ b/AIPscan/Reporter/report_originals_with_derivatives.py
@@ -7,7 +7,7 @@ the different file formats associated with both.
 from flask import render_template, request
 
 from AIPscan.Data import data
-from AIPscan.Reporter import reporter, translate_headers
+from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
 @reporter.route("/original_derivatives/", methods=["GET"])
@@ -16,7 +16,7 @@ def original_derivatives():
     exist.
     """
     aips_with_preservation_files = []
-    storage_service_id = request.args.get("amss_id")
+    storage_service_id = request.args.get(request_params["storage_service_id"])
     derivative_data = data.derivative_overview(storage_service_id=storage_service_id)
     storage_service_name = derivative_data[data.FIELD_STORAGE_NAME]
 

--- a/AIPscan/Reporter/templates/report_aips_by_format.html
+++ b/AIPscan/Reporter/templates/report_aips_by_format.html
@@ -1,0 +1,46 @@
+{% extends "report_base.html" %}
+
+{% block content %}
+
+  <div class="alert alert-secondary">
+    <a class="noprint" onClick="window.print();return false">
+    	<button type="button" class="btn btn-info" style="float:right;">Print</button>
+    </a>
+    <strong>Report: AIPs by File Format</strong>
+    <br>
+    <strong>Storage Service:</strong> {{ storage_service_name }}</strong>
+    <br>
+    <strong>File format:</strong> {{ file_format }}
+    <br>
+    {% if original_files %}
+      <strong>File type:</strong> original files
+    {% else %}
+      <strong>File type:</strong> preservation files
+    {% endif %}
+  </div>
+
+  {% if aips %}
+    <table class="table table-striped table-bordered">
+    	<thead>
+        <tr>
+        {% for column in columns %}
+          <th>{{ column }}</th>
+        {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for aip in aips %}
+          <tr>
+            <td>{{ aip["AIPName"] }}</td>
+            <td>{{ aip["UUID"] }}</td>
+            <td>{{ aip["Count"] }}</td>
+            <td>{{ aip["Size"] | filesizeformat }} </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="h4" style="margin-top:20px;">No AIPs with file format "{{ file_format }}" to display.</p>
+  {% endif %}
+
+{% endblock %}

--- a/AIPscan/Reporter/templates/report_aips_by_puid.html
+++ b/AIPscan/Reporter/templates/report_aips_by_puid.html
@@ -1,0 +1,50 @@
+{% extends "report_base.html" %}
+
+{% block content %}
+
+  <div class="alert alert-secondary">
+    <a class="noprint" onClick="window.print();return false">
+    	<button type="button" class="btn btn-info" style="float:right;">Print</button>
+    </a>
+    <strong>Report: AIPs by PUID</strong>
+    <br>
+    <strong>Storage Service:</strong> {{ storage_service_name }}</strong>
+    <br>
+    <strong>PUID:</strong> {{ puid }}
+    {% if file_format %}
+      <br>
+      <strong>File format and version:</strong> {{ file_format }}
+    {% endif %}
+    <br>
+    {% if original_files %}
+      <strong>File type:</strong> original files
+    {% else %}
+      <strong>File type:</strong> preservation files
+    {% endif %}
+  </div>
+
+  {% if aips %}
+    <table class="table table-striped table-bordered">
+    	<thead>
+        <tr>
+        {% for column in columns %}
+          <th>{{ column }}</th>
+        {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+        {% for aip in aips %}
+          <tr>
+            <td>{{ aip["AIPName"] }}</td>
+            <td>{{ aip["UUID"] }}</td>
+            <td>{{ aip["Count"] }}</td>
+            <td>{{ aip["Size"] | filesizeformat }} </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="h4" style="margin-top:20px;">No AIPs with PUID "{{ puid }}" to display.</p>
+  {% endif %}
+
+{% endblock %}

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -2,35 +2,33 @@
 
 {% block content %}
 
-<!--TODO container-fluid is also present on base.html should this be a
-    different class?
--->
-<div class="container-fluid">
+<div class="container-alert"></div>
 
-    <!-- TODO: Same question as container-fluid for consistency across the
-         application.
-    -->
-    <div class="container-alert"></div>
+<div class="alert alert-header"><strong>Reports</strong></div>
 
-    <div class="alert alert-header"><strong>Reports</strong></div>
+{% if storage_services %}
 
-    <div style="padding-left: 1.25rem;">
+    <div style="padding-left: 1em;">
         <strong>Storage service:</strong>
         <select id="ss" method="GET" action="/" class="form-control" style="width:auto;">
             {% for ss in storage_services %}
-            {% if ss.default == 1 %}
-            <option value="{{ ss.id }}" SELECTED>{{ ss.name }}</option>
-            {% else %}
-            <option value="{{ ss.id }}">{{ ss.name }}</option>
-            {% endif %}
+              {% if ss.id == storage_service.id %}
+                <option value="{{ ss.id }}" SELECTED>{{ ss.name }}</option>
+              {% else %}
+                <option value="{{ ss.id }}">{{ ss.name }}</option>
+              {% endif %}
             {% endfor %}
         </select>
     </div>
+
+    <!-- Original file formats indicates data has been fetched for this Storage Service -->
+    {% if original_file_formats %}
 
     <table class="table table-striped table-bordered" style="margin: 1.25rem;">
 
         <tr>
             <th>Report</th>
+            <th>File format/PUID</th>
             <th><img src="{{ url_for('static', filename='assets/calendar-icon.png') }}" style="height: 1.5em; margin-right: 5px;" />Start date</th>
             <th><img src="{{ url_for('static', filename='assets/calendar-icon.png') }}" style="height: 1.5em; margin-right: 5px;" />End date</th>
             <th>Format</th>
@@ -38,6 +36,7 @@
 
         <tr>
             <td>File format count</td>
+            <td></td>
             <td><input id="startdate1" type="text" value="{{ start_date }}">
             </td>
             <td><input type="text" id="enddate1" value="{{ end_date }}"></td>
@@ -48,11 +47,13 @@
             <td>AIP contents</td>
             <td></td>
             <td></td>
+            <td></td>
             <td><a href="#"><button type="button" id="report2a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
         </tr>
 
         <tr>
             <td>Format version count</td>
+            <td></td>
             <td></td>
             <td></td>
             <td><a href="#"><button type="button" id="report3a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
@@ -62,6 +63,7 @@
             <td>Preservation copy count</td>
             <td></td>
             <td></td>
+            <td></td>
             <td><a href="#"><button type="button" id="report4a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
         </tr>
 
@@ -69,12 +71,104 @@
             <td>Largest files</td>
             <td></td>
             <td></td>
+            <td></td>
             <td><a href="#"><button type="button" id="report9a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
         </tr>
 
+        <tr>
+            <td>
+                File format
+                <br>
+                <span class="text-muted">AIPs containing original files in given file format.</span>
+            </td>
+            <td>
+              <select id="originalFormatSelect" method="GET" action="/" class="form-control" style="width:auto;">
+                {% for file_format in original_file_formats %}
+                  <option value="{{ file_format }}">{{ file_format }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td></td>
+            <td></td>
+            <td><a href="#"><button type="button" id="aipsByOriginalFormat" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+        </tr>
+
+        <tr>
+            <td>
+                File format version
+                <br>
+                <span class="text-muted">AIPs containing original files in given file format version, specified by PUID.</span>
+            </td>
+            <td>
+              <select id="originalPUIDSelect" method="GET" action="/" class="form-control" style="width:auto;">
+                {% for puid in original_puids %}
+                  <option value="{{ puid }}">{{ puid }}</option>
+                {% endfor %}
+              </select>
+            </td>
+            <td></td>
+            <td></td>
+            <td><a href="#"><button type="button" id="aipsByOriginalPUID" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+        </tr>
+
+        {% if preservation_file_formats %}
+            <tr>
+                <td>
+                    File format (preservation)
+                    <br>
+                    <span class="text-muted">AIPs containing normalized preservation derivatives in given file format.</span>
+                </td>
+                <td>
+                  <select id="preservationFormatSelect" method="GET" action="/" class="form-control" style="width:auto;">
+                    {% for file_format in preservation_file_formats %}
+                      <option value="{{ file_format }}">{{ file_format }}</option>
+                    {% endfor %}
+                  </select>
+                </td>
+                <td></td>
+                <td></td>
+                <td><a href="#"><button type="button" id="aipsByPreservationFormat" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+            </tr>
+        {% endif %}
+
+        {% if preservation_puids %}
+            <tr>
+                <td>
+                    File format version (preservation)
+                    <br>
+                    <span class="text-muted">AIPs containing normalized preservation derivatives in given file format version, specified by PUID.</span>
+                </td>
+                <td>
+                  <select id="preservationPUIDSelect" method="GET" action="/" class="form-control" style="width:auto;">
+                    {% for puid in preservation_puids %}
+                      <option value="{{ puid }}">{{ puid }}</option>
+                    {% endfor %}
+                  </select>
+                </td>
+                <td></td>
+                <td></td>
+                <td><a href="#"><button type="button" id="aipsByPreservationPUID" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+            </tr>
+        {% endif %}
+
     </table>
 
-</div>
+    {% else %}
+
+    <div style="padding:1em;">
+        No data available. Run a Fetch Job to populate AIPscan with data from this Storage Service or select a different Storage Service.
+    </div>
+
+    {% endif %}
+
+{% else %}
+
+    <div style="padding:1em;">
+        Storage Service information is not yet available for reporting. <a href="{{ url_for('aggregator.storage_services') }}">Configure a Storage Service</a> and run a Fetch Job to get started.</a>
+    </div>
+
+{% endif %}
+
 
 <!-- TODO: Let's get this into a separate JS and import it... -->
 <script>
@@ -89,7 +183,7 @@
     //
     // TODO: Are there more idiomatic approaches? 🤷
     bootstrap_alert = function(message, alertType) {
-      $("body > div.container-fluid > div > div.container-alert").html(
+      $("body > div > div.container-alert").html(
         '<div class="alert alert-' +
         alertType +
         '"><a class="close" data-dismiss="alert">×</a><span>' +
@@ -99,6 +193,18 @@
     }
 
     $(document).ready(function() {
+        // Refresh page with storage_service_id parameter when user selects a
+        // Storage Service from the dropdown list. This enables us to provide
+        // lists of the file formats and PUIDs in a given Storage Service to
+        // the reports template for use in dropdown selectors.
+        $("#ss").on("change", function() {
+          var storageServiceId = $('#ss').val();
+          var url = window.location.origin +
+            '/reporter/reports?' +
+            'amss_id=' +
+            storageServiceId;
+          window.location.href = url;
+        });
         $("#startdate1").datepicker({
             dateFormat: 'yy-mm-dd',
             onSelect: function(date) {
@@ -129,11 +235,11 @@
             } else {
                 var storageServiceId = $('#ss').val();
                 var url = window.location.origin +
-                    '/reporter/report_formats_count?startdate=' +
+                    '/reporter/report_formats_count?start_date=' +
                     startdate +
-                    '&enddate=' +
+                    '&end_date=' +
                     enddate +
-                    '&ssId=' +
+                    '&amss_id=' +
                     storageServiceId
                 window.open(url);
             }
@@ -146,11 +252,11 @@
             } else {
                 var storageServiceId = $('#ss').val();
                 var url = window.location.origin +
-                    '/reporter/chart_formats_count?startdate=' +
+                    '/reporter/chart_formats_count?start_date=' +
                     startdate +
-                    '&enddate=' +
+                    '&end_date=' +
                     enddate +
-                    '&ssId=' +
+                    '&amss_id=' +
                     storageServiceId
                 window.open(url);
             }
@@ -163,11 +269,11 @@
             } else {
                 var storageServiceId = $('#ss').val();
                 var url = window.location.origin +
-                    '/reporter/plot_formats_count?startdate=' +
+                    '/reporter/plot_formats_count?start_date=' +
                     startdate +
-                    '&enddate=' +
+                    '&end_date=' +
                     enddate +
-                    '&ssId=' +
+                    '&amss_id=' +
                     storageServiceId
                 window.open(url);
             }
@@ -207,6 +313,66 @@
               URL_LARGEST_FILES +
               '?amss_id=' +
               storageServiceID
+            );
+            window.open(url);
+        });
+        $("#aipsByOriginalFormat").on("click", function() {
+            const URL_AIP_CONTENTS = "/reporter/aips_by_file_format/";
+            var storageServiceID = $('#ss').val();
+            var fileFormat = $('#originalFormatSelect').val();
+            var url = (
+              window.location.origin +
+              URL_AIP_CONTENTS +
+              '?amss_id=' +
+              storageServiceID +
+              '&file_format=' +
+              fileFormat +
+              '&original_files=True'
+            );
+            window.open(url);
+        });
+        $("#aipsByPreservationFormat").on("click", function() {
+            const URL_AIP_CONTENTS = "/reporter/aips_by_file_format/";
+            var storageServiceID = $('#ss').val();
+            var fileFormat = $('#preservationFormatSelect').val();
+            var url = (
+              window.location.origin +
+              URL_AIP_CONTENTS +
+              '?amss_id=' +
+              storageServiceID +
+              '&file_format=' +
+              fileFormat +
+              '&original_files=False'
+            );
+            window.open(url);
+        });
+        $("#aipsByOriginalPUID").on("click", function() {
+            const URL_AIP_CONTENTS = "/reporter/aips_by_puid/";
+            var storageServiceID = $('#ss').val();
+            var puid = $('#originalPUIDSelect').val();
+            var url = (
+              window.location.origin +
+              URL_AIP_CONTENTS +
+              '?amss_id=' +
+              storageServiceID +
+              '&puid=' +
+              puid +
+              '&original_files=True'
+            );
+            window.open(url);
+        });
+        $("#aipsByPreservationPUID").on("click", function() {
+            const URL_AIP_CONTENTS = "/reporter/aips_by_puid/";
+            var storageServiceID = $('#ss').val();
+            var puid = $('#preservationPUIDSelect').val();
+            var url = (
+              window.location.origin +
+              URL_AIP_CONTENTS +
+              '?amss_id=' +
+              storageServiceID +
+              '&puid=' +
+              puid +
+              '&original_files=False'
             );
             window.open(url);
         });

--- a/AIPscan/Reporter/tests/test_aips_by_puid.py
+++ b/AIPscan/Reporter/tests/test_aips_by_puid.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+import datetime
+import pytest
+import uuid
+
+from AIPscan.Reporter.report_aips_by_puid import get_format_string_from_puid
+from AIPscan.models import File, FileType
+
+FILE_WITH_FORMAT_ONLY = File(
+    uuid=uuid.uuid4(),
+    name="test.txt",
+    size=12345,
+    aip_id=2,
+    file_type=FileType.original,
+    file_format="Plain Text File",
+    puid="x-fmt/111",
+    filepath="/path/to/file.txt",
+    date_created=datetime.datetime.now(),
+    checksum_type="md5",
+    checksum_value="anotherfakemd5",
+)
+
+FILE_WITH_FORMAT_AND_VERSION = File(
+    uuid=uuid.uuid4(),
+    name="test.pdf",
+    size=12345678,
+    aip_id=1,
+    file_type=FileType.preservation,
+    file_format="Acrobat PDF/A - Portable Document Format",
+    format_version="1b",
+    puid="fmt/354",
+    filepath="/path/to/test.pdf",
+    date_created=datetime.datetime.now(),
+    checksum_type="md5",
+    checksum_value="yetanotherfakemd5",
+    original_file_id=1,
+)
+
+FILE_WITH_NO_FORMAT = File(
+    uuid=uuid.uuid4(),
+    name="test.txt",
+    size=12345,
+    aip_id=2,
+    file_type=FileType.original,
+    file_format=None,
+    puid="x-fmt/111",
+    filepath="/path/to/file.txt",
+    date_created=datetime.datetime.now(),
+    checksum_type="md5",
+    checksum_value="anotherfakemd5",
+)
+
+
+@pytest.mark.parametrize(
+    "puid, mock_file, expected_return_value",
+    [
+        ("x-fmt/111", FILE_WITH_FORMAT_ONLY, "Plain Text File"),
+        (
+            "fmt/354",
+            FILE_WITH_FORMAT_AND_VERSION,
+            "Acrobat PDF/A - Portable Document Format (1b)",
+        ),
+        ("x-fmt/111", FILE_WITH_NO_FORMAT, None),
+        ("fmt/123", None, None),
+    ],
+)
+def test_get_format_name_and_version_from_puid(
+    app_instance, mocker, puid, mock_file, expected_return_value
+):
+    """Test that helper function returns expected string or None.
+    """
+    mock_get_file = mocker.patch("sqlalchemy.orm.query.Query.first")
+    mock_get_file.return_value = mock_file
+    assert expected_return_value == get_format_string_from_puid(puid)

--- a/AIPscan/conftest.py
+++ b/AIPscan/conftest.py
@@ -8,7 +8,7 @@ from AIPscan import db, create_app
 
 
 @pytest.fixture
-def app_instance():
+def app_instance(scope="session"):
     """Pytest fixture that returns an instance of our application.
 
     This fixture provides a Flask application context for tests using

--- a/AIPscan/helpers.py
+++ b/AIPscan/helpers.py
@@ -1,5 +1,14 @@
 # -*- coding: utf-8 -*-
 
+from distutils.util import strtobool
+
+
+def parse_bool(val, default=True):
+    try:
+        return bool(strtobool(val))
+    except (ValueError, AttributeError):
+        return default
+
 
 def get_human_readable_file_size(size, precision=2):
     suffixes = ["B", "KiB", "MiB", "GiB", "TiB"]

--- a/AIPscan/models.py
+++ b/AIPscan/models.py
@@ -46,6 +46,50 @@ class StorageService(db.Model):
     def __repr__(self):
         return "<Storage Service '{}'>".format(self.name)
 
+    @property
+    def unique_file_formats(self):
+        return (
+            db.session.query(File.file_format.distinct().label("name"))
+            .join(AIP)
+            .join(StorageService)
+            .filter(StorageService.id == self.id)
+            .order_by(File.file_format)
+        )
+
+    @property
+    def unique_original_file_formats(self):
+        formats = self.unique_file_formats
+        original_formats = formats.filter(File.file_type == FileType.original)
+        return [format_.name for format_ in original_formats]
+
+    @property
+    def unique_preservation_file_formats(self):
+        formats = self.unique_file_formats
+        preservation_formats = formats.filter(File.file_type == FileType.preservation)
+        return [format_.name for format_ in preservation_formats]
+
+    @property
+    def unique_puids(self):
+        return (
+            db.session.query(File.puid.distinct().label("puid"))
+            .join(AIP)
+            .join(StorageService)
+            .filter(StorageService.id == self.id)
+            .order_by(File.puid)
+        )
+
+    @property
+    def unique_original_puids(self):
+        puids = self.unique_puids
+        original_puids = puids.filter(File.file_type == FileType.original)
+        return [puid.puid for puid in original_puids if puid.puid is not None]
+
+    @property
+    def unique_preservation_puids(self):
+        puids = self.unique_puids
+        preservation_puids = puids.filter(File.file_type == FileType.preservation)
+        return [puid.puid for puid in preservation_puids if puid.puid is not None]
+
 
 class FetchJob(db.Model):
     __tablename__ = "fetch_job"

--- a/AIPscan/templates/base.html
+++ b/AIPscan/templates/base.html
@@ -25,7 +25,7 @@
     <div class="navbar-collapse" id="navbarNavDropdown">
       <ul class="navbar-nav">
         <li class="nav-item">
-          <a class="nav-link" href="{{ url_for('aggregator.ss') }}">Archivematica Storage Services</a>
+          <a class="nav-link" href="{{ url_for('aggregator.storage_services') }}">Archivematica Storage Services</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="{{ url_for('reporter.view_aips') }}">AIPs</a>

--- a/AIPscan/templates/report_base.html
+++ b/AIPscan/templates/report_base.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>AIPscan - Report</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/jquery-ui.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/bootstrap.min.css') }}">
+    <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/custom.css') }}">
+
+
+    <script type="text/javascript" language="javascript" src="{{ url_for('static', filename='js/jquery-3.3.1.js') }}"></script>
+    <script type="text/javascript" language="javascript" src="{{ url_for('static', filename='js/jquery-ui.js') }}"></script>
+    <script type="text/javascript" language="javascript" src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+
+    {% include "datatable.html" %}
+</head>
+
+<body>
+  <div class="container-fluid" style="margin: 20px 0;">
+
+    {% block content %}
+    {% endblock %}
+
+  </div>
+</body>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,7 @@ kombu==4.6.10
 lxml==4.5.0
 MarkupSafe==1.1.1
 metsrw==0.3.15
+natsort==7.0.1
 pytz==2020.1
 requests==2.23.0
 six==1.14.0


### PR DESCRIPTION
Connected to #75 

This PR adds reports that take a file format or PUID as input and provide a sorted list of AIPs containing that format/PUID.

This was intended to show/explore what's possible in terms of format reporting with the data we have from the METS files, so higher-level groupings (e.g. format groups from the FPR) are not included.

Also included is a second commit which simply removes an outdated `TODO` comment on the largest files report, which didn't seem worth the overhead of a separate issue and PR.

## Screenshots

**Reports page**

![image](https://user-images.githubusercontent.com/6758804/96650740-61b3cb00-1301-11eb-8212-32fe2a6513c2.png)

The dropdown lists are populated from new `unique_file_formats` and `unique_puids` properties on the `StorageService` model, and so only contain formats/PUIDs found in the AIPs in the currently selected Storage Service. It's possible these dropdowns might get a bit unwieldy when AIPscan is pointed to a Storage Service with lots of AIPs containing a heterogeneous mix of formats, with an upper bound of being equivalent to the very large dropdown menus in the FPR.

I'm very open to any suggestions for how to make the UI more appealing or user-friendly!

**AIPs by File Format report**

![image](https://user-images.githubusercontent.com/6758804/96650776-6f695080-1301-11eb-9f8c-7853de0fca3f.png)

**AIPs by PUID report**

![image](https://user-images.githubusercontent.com/6758804/96650806-7e500300-1301-11eb-9f8e-a161900b828d.png)

