### PR TITLE
Add format versions count report

### DIFF
--- a/AIPscan/API/fields.py
+++ b/AIPscan/API/fields.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+"""Field name constants."""
+
+FIELD_FILE_FORMAT = "file_format"
+FIELD_FILE_TYPE = "file_type"
+FIELD_LIMIT = "limit"
+FIELD_ORIGINAL_FILES = "original_files"
+FIELD_PUID = "puid"
+FIELD_START_DATE = "start_date"
+FIELD_END_DATE = "end_date"

--- a/AIPscan/API/namespace_data.py
+++ b/AIPscan/API/namespace_data.py
@@ -11,13 +11,8 @@ from flask import request
 from flask_restx import Namespace, Resource
 
 from AIPscan.helpers import parse_bool
+from AIPscan.API import fields
 from AIPscan.Data import data
-
-FILE_FORMAT_FIELD = "file_format"
-FILE_TYPE_FIELD = "file_type"
-LIMIT_FIELD = "limit"
-ORIGINAL_FILES_FIELD = "original_files"
-PUID_FIELD = "puid"
 
 api = Namespace("data", description="Retrieve data from AIPscan to shape as you desire")
 
@@ -34,7 +29,7 @@ class FMTList(Resource):
     @api.doc(
         "list_formats",
         params={
-            ORIGINAL_FILES_FIELD: {
+            fields.FIELD_ORIGINAL_FILES: {
                 "description": "Return data for original files or copies",
                 "in": "query",
                 "type": "bool",
@@ -43,7 +38,7 @@ class FMTList(Resource):
     )
     def get(self, storage_service_id):
         """List PUIDs and AIPs containing examples of them"""
-        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
+        original_files = parse_bool(request.args.get(fields.FIELD_ORIGINAL_FILES, True))
         aip_data = data.aip_overview(
             storage_service_id=storage_service_id, original_files=original_files
         )
@@ -55,7 +50,7 @@ class AIPList(Resource):
     @api.doc(
         "list_formats",
         params={
-            ORIGINAL_FILES_FIELD: {
+            fields.FIELD_ORIGINAL_FILES: {
                 "description": "Return data for original files or preservation derivatives",
                 "in": "query",
                 "type": "bool",
@@ -64,7 +59,7 @@ class AIPList(Resource):
     )
     def get(self, storage_service_id):
         """List AIPs and a summary of the file formats they contain"""
-        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
+        original_files = parse_bool(request.args.get(fields.FIELD_ORIGINAL_FILES, True))
         aip_data = data.aip_overview_two(
             storage_service_id=storage_service_id, original_files=original_files
         )
@@ -78,99 +73,3 @@ class DerivativeList(Resource):
         """List original and derivative identifiers per AIP"""
         aip_data = data.derivative_overview(storage_service_id=storage_service_id)
         return aip_data
-
-
-@api.route("/largest-files/<storage_service_id>")
-class LargestFileList(Resource):
-    @api.doc(
-        "list_formats",
-        params={
-            FILE_TYPE_FIELD: {
-                "description": "Optional file type filter (original or preservation)",
-                "in": "query",
-                "type": "str",
-            },
-            LIMIT_FIELD: {
-                "description": "Number of results to return (default is 20)",
-                "in": "query",
-                "type": "int",
-            },
-        },
-    )
-    def get(self, storage_service_id, file_type=None, limit=20):
-        """Largest files"""
-        file_type = request.args.get(FILE_TYPE_FIELD)
-        try:
-            limit = int(request.args.get("limit", 20))
-        except ValueError:
-            pass
-        file_data = data.largest_files(
-            storage_service_id=storage_service_id, file_type=file_type, limit=limit
-        )
-        return file_data
-
-
-@api.route("/aips-by-file-format/<storage_service_id>")
-class AIPsByFormatList(Resource):
-    @api.doc(
-        "list_aips_by_format",
-        params={
-            FILE_FORMAT_FIELD: {
-                "description": "File format name (must be exact match)",
-                "in": "query",
-                "type": "str",
-            },
-            ORIGINAL_FILES_FIELD: {
-                "description": "Return data for original files or preservation derivatives",
-                "in": "query",
-                "type": "bool",
-            },
-        },
-    )
-    def get(self, storage_service_id):
-        """AIPs containing given file format."""
-        file_format = request.args.get(FILE_FORMAT_FIELD, "")
-        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
-        aip_data = data.aips_by_file_format(
-            storage_service_id=storage_service_id,
-            file_format=file_format,
-            original_files=original_files,
-        )
-        return aip_data
-
-
-@api.route("/aips-by-puid/<storage_service_id>")
-class AIPsByPUIDList(Resource):
-    @api.doc(
-        "list_aips_by_puid",
-        params={
-            PUID_FIELD: {
-                "description": "PRONOM ID (PUID)",
-                "in": "query",
-                "type": "str",
-            },
-            ORIGINAL_FILES_FIELD: {
-                "description": "Return data for original files or preservation derivatives",
-                "in": "query",
-                "type": "bool",
-            },
-        },
-    )
-    def get(self, storage_service_id):
-        """AIPs containing given format version, specified by PUID."""
-        puid = request.args.get(PUID_FIELD, "")
-        original_files = parse_bool(request.args.get(ORIGINAL_FILES_FIELD, True))
-        aip_data = data.aips_by_puid(
-            storage_service_id=storage_service_id,
-            puid=puid,
-            original_files=original_files,
-        )
-        return aip_data
-
-
-@api.route("/agents-transfers/<storage_service_id>")
-class AgentData(Resource):
-    @api.doc("agent info")
-    def get(self, storage_service_id):
-        """List user agents and their transfers"""
-        return data.agents_transfers(storage_service_id=storage_service_id)

--- a/AIPscan/API/namespace_report_data.py
+++ b/AIPscan/API/namespace_report_data.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+
+"""Report data namespace
+
+Return data optimized for reports implemented in the Reporter
+blueprint for consumption by external systems.
+"""
+
+from flask import request
+from flask_restx import Namespace, Resource
+
+from AIPscan.helpers import parse_bool, parse_datetime_bound
+from AIPscan.API import fields
+from AIPscan.Data import report_data
+
+api = Namespace(
+    "report-data", description="Retrieve data optimized for AIPscan reports"
+)
+
+
+@api.route("/format-version-count/<storage_service_id>")
+class FormatVersionList(Resource):
+    @api.doc(
+        "list_format_versions",
+        params={
+            fields.FIELD_START_DATE: {
+                "description": "AIP creation start date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_END_DATE: {
+                "description": "AIP creation end date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
+        },
+    )
+    def get(self, storage_service_id):
+        """List file format versions with file count and size"""
+        start_date = parse_datetime_bound(request.args.get(fields.FIELD_START_DATE))
+        end_date = parse_datetime_bound(
+            request.args.get(fields.FIELD_END_DATE), upper=True
+        )
+
+        return report_data.format_versions_count(
+            storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+
+@api.route("/largest-files/<storage_service_id>")
+class LargestFileList(Resource):
+    @api.doc(
+        "list_formats",
+        params={
+            fields.FIELD_FILE_TYPE: {
+                "description": "Optional file type filter (original or preservation)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_LIMIT: {
+                "description": "Number of results to return (default is 20)",
+                "in": "query",
+                "type": "int",
+            },
+        },
+    )
+    def get(self, storage_service_id, file_type=None, limit=20):
+        """List largest files"""
+        file_type = request.args.get(fields.FIELD_FILE_TYPE)
+        try:
+            limit = int(request.args.get(fields.FIELD_LIMIT, 20))
+        except ValueError:
+            pass
+        return report_data.largest_files(
+            storage_service_id=storage_service_id, file_type=file_type, limit=limit
+        )
+
+
+@api.route("/aips-by-file-format/<storage_service_id>")
+class AIPsByFormatList(Resource):
+    @api.doc(
+        "list_aips_by_format",
+        params={
+            fields.FIELD_FILE_FORMAT: {
+                "description": "File format name (must be exact match)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_ORIGINAL_FILES: {
+                "description": "Return data for original files (default) or preservation derivatives",
+                "in": "query",
+                "type": "bool",
+            },
+        },
+    )
+    def get(self, storage_service_id):
+        """List AIPs containing given file format"""
+        file_format = request.args.get(fields.FIELD_FILE_FORMAT, "")
+        original_files = parse_bool(request.args.get(fields.FIELD_ORIGINAL_FILES, True))
+        return report_data.aips_by_file_format(
+            storage_service_id=storage_service_id,
+            file_format=file_format,
+            original_files=original_files,
+        )
+
+
+@api.route("/aips-by-puid/<storage_service_id>")
+class AIPsByPUIDList(Resource):
+    @api.doc(
+        "list_aips_by_puid",
+        params={
+            fields.FIELD_PUID: {
+                "description": "PRONOM ID (PUID)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_ORIGINAL_FILES: {
+                "description": "Return data for original files (default) or preservation derivatives",
+                "in": "query",
+                "type": "bool",
+            },
+        },
+    )
+    def get(self, storage_service_id):
+        """List AIPs containing given format version, specified by PUID"""
+        puid = request.args.get(fields.FIELD_PUID, "")
+        original_files = parse_bool(request.args.get(fields.FIELD_ORIGINAL_FILES, True))
+        return report_data.aips_by_puid(
+            storage_service_id=storage_service_id,
+            puid=puid,
+            original_files=original_files,
+        )
+
+
+@api.route("/agents-transfers/<storage_service_id>")
+class AgentData(Resource):
+    @api.doc("agent_info")
+    def get(self, storage_service_id):
+        """List user agents and their transfers"""
+        return report_data.agents_transfers(storage_service_id=storage_service_id)

--- a/AIPscan/API/views.py
+++ b/AIPscan/API/views.py
@@ -16,7 +16,8 @@ from flask import Blueprint
 from flask_restx import Api
 
 from .namespace_data import api as ns1
-from .namespace_infos import api as ns2
+from .namespace_report_data import api as ns2
+from .namespace_infos import api as ns3
 
 api_doc = """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
@@ -40,3 +41,4 @@ report_api = Api(
 
 report_api.add_namespace(ns1)
 report_api.add_namespace(ns2)
+report_api.add_namespace(ns3)

--- a/AIPscan/Data/__init__.py
+++ b/AIPscan/Data/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from AIPscan.models import StorageService
+
+
+def _get_storage_service(storage_service_id):
+    """Return Storage Service with ID or None.
+
+    Unlike elsewhere in our application, here we do not fall back to
+    a different StorageService if the user-supplied ID is invalid to
+    prevent inaccurate information from being returned.
+
+    :param storage_service_id: Storage Service ID
+
+    :returns: StorageService object or None
+    """
+    return StorageService.query.get(storage_service_id)

--- a/AIPscan/Data/data.py
+++ b/AIPscan/Data/data.py
@@ -1,80 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from AIPscan import db
+"""Data endpoints optimized for providing general overviews of AIPs."""
+
+from AIPscan.Data import _get_storage_service, fields
 from AIPscan.helpers import _simplify_datetime
-from AIPscan.models import AIP, Event, File, FileType, StorageService
-
-VALID_FILE_TYPES = set(item.value for item in FileType)
-
-FIELD_AIP_ID = "AIPID"
-FIELD_AIP_NAME = "AIPName"
-FIELD_AIP_SIZE = "AIPSize"
-FIELD_AIP_UUID = "AIPUUID"
-FIELD_AIPS = "AIPs"
-FIELD_ALL_AIPS = "AllAIPs"
-
-FIELD_COUNT = "Count"
-FIELD_CREATED_DATE = "CreatedDate"
-
-FIELD_DERIVATIVE_COUNT = "DerivativeCount"
-FIELD_DERIVATIVE_FORMAT = "DerivativeFormat"
-FIELD_DERIVATIVE_UUID = "DerivativeUUID"
-
-FIELD_EVENT = "Event"
-
-FIELD_FILES = "Files"
-FIELD_FILE_COUNT = "FileCount"
-FIELD_FILE_TYPE = "FileType"
-FIELD_FILENAME = "Filename"
-FIELD_FORMAT = "Format"
-FIELD_FORMATS = "Formats"
-
-FIELD_INGESTS = "Ingests"
-FIELD_INGEST_START_DATE = "IngestStartDate"
-FIELD_INGEST_FINISH_DATE = "IngestFinishDate"
-
-FIELD_NAME = "Name"
-
-FIELD_ORIGINAL_UUID = "OriginalUUID"
-FIELD_ORIGINAL_FORMAT = "OriginalFormat"
-
-FIELD_PUID = "PUID"
-
-FIELD_RELATED_PAIRING = "RelatedPairing"
-
-FIELD_SIZE = "Size"
-FIELD_STORAGE_NAME = "StorageName"
-
-FIELD_TRANSFER_NAME = "TransferName"
-
-FIELD_USER = "User"
-FIELD_UUID = "UUID"
-
-FIELD_VERSION = "Version"
-
-
-def _get_storage_service(storage_service_id):
-    """Return Storage Service with ID or None.
-
-    Unlike elsewhere in our application, here we do not fall back to
-    a different StorageService if the user-supplied ID is invalid to
-    prevent inaccurate information from being returned.
-
-    :param storage_service_id: Storage Service ID
-
-    :returns: StorageService object or None
-    """
-    return StorageService.query.get(storage_service_id)
-
-
-def _get_username(agent_string):
-    """Retrieve username from the standard agent string stored in the
-    database, normally formatted as:
-
-        * username="test", first_name="", last_name=""
-    """
-    USERNAME = "username="
-    return agent_string.split(",", 1)[0].replace(USERNAME, "").replace('"', "")
+from AIPscan.models import AIP, File, FileType
 
 
 def aip_overview(storage_service_id, original_files=True):
@@ -96,20 +26,22 @@ def aip_overview(storage_service_id, original_files=True):
             except AttributeError:
                 format_key = file_.file_format
             if format_key in report:
-                report[format_key][FIELD_COUNT] = report[format_key][FIELD_COUNT] + 1
-                if aip.uuid not in report[format_key][FIELD_AIPS]:
-                    report[format_key][FIELD_AIPS].append(aip.uuid)
+                report[format_key][fields.FIELD_COUNT] = (
+                    report[format_key][fields.FIELD_COUNT] + 1
+                )
+                if aip.uuid not in report[format_key][fields.FIELD_AIPS]:
+                    report[format_key][fields.FIELD_AIPS].append(aip.uuid)
             else:
                 report[format_key] = {}
-                report[format_key][FIELD_COUNT] = 1
+                report[format_key][fields.FIELD_COUNT] = 1
                 try:
-                    report[format_key][FIELD_VERSION] = file_.format_version
-                    report[format_key][FIELD_NAME] = file_.file_format
+                    report[format_key][fields.FIELD_VERSION] = file_.format_version
+                    report[format_key][fields.FIELD_NAME] = file_.file_format
                 except AttributeError:
                     pass
-                if report[format_key].get(FIELD_AIPS) is None:
-                    report[format_key][FIELD_AIPS] = []
-                report[format_key][FIELD_AIPS].append(aip.uuid)
+                if report[format_key].get(fields.FIELD_AIPS) is None:
+                    report[format_key][fields.FIELD_AIPS] = []
+                report[format_key][fields.FIELD_AIPS].append(aip.uuid)
     return report
 
 
@@ -124,12 +56,12 @@ def aip_overview_two(storage_service_id, original_files=True):
     aips = AIP.query.filter_by(storage_service_id=storage_service.id).all()
     for aip in aips:
         report[aip.uuid] = {}
-        report[aip.uuid][FIELD_AIP_NAME] = aip.transfer_name
-        report[aip.uuid][FIELD_CREATED_DATE] = _simplify_datetime(
+        report[aip.uuid][fields.FIELD_AIP_NAME] = aip.transfer_name
+        report[aip.uuid][fields.FIELD_CREATED_DATE] = _simplify_datetime(
             aip.create_date, False
         )
-        report[aip.uuid][FIELD_AIP_SIZE] = 0
-        report[aip.uuid][FIELD_FORMATS] = {}
+        report[aip.uuid][fields.FIELD_AIP_SIZE] = 0
+        report[aip.uuid][fields.FIELD_FORMATS] = {}
         files = None
         format_key = None
         if original_files is True:
@@ -149,31 +81,37 @@ def aip_overview_two(storage_service_id, original_files=True):
                 )
             except AttributeError:
                 formats[format_key] = "{}".format(file_.file_format)
-            size = report[aip.uuid][FIELD_AIP_SIZE]
+            size = report[aip.uuid][fields.FIELD_AIP_SIZE]
             try:
-                report[aip.uuid][FIELD_AIP_SIZE] = size + file_.size
+                report[aip.uuid][fields.FIELD_AIP_SIZE] = size + file_.size
             # TODO: Find out why size is sometimes None.
             except TypeError:
-                report[aip.uuid][FIELD_AIP_SIZE] = size
+                report[aip.uuid][fields.FIELD_AIP_SIZE] = size
                 pass
-            if format_key not in report[aip.uuid][FIELD_FORMATS]:
-                report[aip.uuid][FIELD_FORMATS][format_key] = {}
-                report[aip.uuid][FIELD_FORMATS][format_key][FIELD_COUNT] = 1
+            if format_key not in report[aip.uuid][fields.FIELD_FORMATS]:
+                report[aip.uuid][fields.FIELD_FORMATS][format_key] = {}
+                report[aip.uuid][fields.FIELD_FORMATS][format_key][
+                    fields.FIELD_COUNT
+                ] = 1
                 try:
-                    report[aip.uuid][FIELD_FORMATS][format_key][
-                        FIELD_VERSION
+                    report[aip.uuid][fields.FIELD_FORMATS][format_key][
+                        fields.FIELD_VERSION
                     ] = file_.format_version
-                    report[aip.uuid][FIELD_FORMATS][format_key][
-                        FIELD_NAME
+                    report[aip.uuid][fields.FIELD_FORMATS][format_key][
+                        fields.FIELD_NAME
                     ] = file_.file_format
                 except AttributeError:
                     pass
             else:
-                count = report[aip.uuid][FIELD_FORMATS][format_key][FIELD_COUNT]
-                report[aip.uuid][FIELD_FORMATS][format_key][FIELD_COUNT] = count + 1
+                count = report[aip.uuid][fields.FIELD_FORMATS][format_key][
+                    fields.FIELD_COUNT
+                ]
+                report[aip.uuid][fields.FIELD_FORMATS][format_key][
+                    fields.FIELD_COUNT
+                ] = (count + 1)
 
-    report[FIELD_FORMATS] = formats
-    report[FIELD_STORAGE_NAME] = storage_service.name
+    report[fields.FIELD_FORMATS] = formats
+    report[fields.FIELD_STORAGE_NAME] = storage_service.name
     return report
 
 
@@ -190,11 +128,11 @@ def derivative_overview(storage_service_id):
             continue
 
         aip_report = {}
-        aip_report[FIELD_TRANSFER_NAME] = aip.transfer_name
-        aip_report[FIELD_UUID] = aip.uuid
-        aip_report[FIELD_FILE_COUNT] = aip.original_file_count
-        aip_report[FIELD_DERIVATIVE_COUNT] = aip.preservation_file_count
-        aip_report[FIELD_RELATED_PAIRING] = []
+        aip_report[fields.FIELD_TRANSFER_NAME] = aip.transfer_name
+        aip_report[fields.FIELD_UUID] = aip.uuid
+        aip_report[fields.FIELD_FILE_COUNT] = aip.original_file_count
+        aip_report[fields.FIELD_DERIVATIVE_COUNT] = aip.preservation_file_count
+        aip_report[fields.FIELD_RELATED_PAIRING] = []
 
         original_files = File.query.filter_by(
             aip_id=aip.id, file_type=FileType.original
@@ -208,266 +146,24 @@ def derivative_overview(storage_service_id):
                 continue
 
             file_derivative_pair = {}
-            file_derivative_pair[FIELD_DERIVATIVE_UUID] = preservation_derivative.uuid
-            file_derivative_pair[FIELD_ORIGINAL_UUID] = original_file.uuid
+            file_derivative_pair[
+                fields.FIELD_DERIVATIVE_UUID
+            ] = preservation_derivative.uuid
+            file_derivative_pair[fields.FIELD_ORIGINAL_UUID] = original_file.uuid
             original_format_version = original_file.format_version
             if original_format_version is None:
                 original_format_version = ""
-            file_derivative_pair[FIELD_ORIGINAL_FORMAT] = "{} {} ({})".format(
+            file_derivative_pair[fields.FIELD_ORIGINAL_FORMAT] = "{} {} ({})".format(
                 original_file.file_format, original_format_version, original_file.puid
             )
-            file_derivative_pair[FIELD_DERIVATIVE_FORMAT] = "{}".format(
+            file_derivative_pair[fields.FIELD_DERIVATIVE_FORMAT] = "{}".format(
                 preservation_derivative.file_format
             )
-            aip_report[FIELD_RELATED_PAIRING].append(file_derivative_pair)
+            aip_report[fields.FIELD_RELATED_PAIRING].append(file_derivative_pair)
 
         all_aips.append(aip_report)
 
-    report[FIELD_ALL_AIPS] = all_aips
-    report[FIELD_STORAGE_NAME] = storage_service.name
+    report[fields.FIELD_ALL_AIPS] = all_aips
+    report[fields.FIELD_STORAGE_NAME] = storage_service.name
 
-    return report
-
-
-def _largest_files_query(storage_service_id, file_type, limit):
-    """Fetch file information from database for largest files query
-
-    This is separated into its own helper function to aid in testing.
-    """
-    if file_type is not None and file_type in VALID_FILE_TYPES:
-        files = (
-            File.query.join(AIP)
-            .join(StorageService)
-            .filter(StorageService.id == storage_service_id)
-            .filter(File.file_type == file_type)
-            .order_by(File.size.desc())
-            .limit(limit)
-        )
-    else:
-        files = (
-            File.query.join(AIP)
-            .join(StorageService)
-            .filter(StorageService.id == storage_service_id)
-            .order_by(File.size.desc())
-            .limit(limit)
-        )
-    return files
-
-
-def largest_files(storage_service_id, file_type=None, limit=20):
-    """Return a summary of the largest files in a given Storage Service
-
-    :param storage_service_id: Storage Service ID.
-    :param file_type: Optional filter for type of file to return
-    (acceptable values are "original" or "preservation").
-    :param limit: Upper limit of number of results to return.
-
-    :returns: "report" dict containing following fields:
-        report["StorageName"]: Name of Storage Service queried
-        report["Files"]: List of result files ordered desc by size
-    """
-    report = {}
-    report[FIELD_FILES] = []
-    storage_service = _get_storage_service(storage_service_id)
-    report[FIELD_STORAGE_NAME] = storage_service.name
-
-    files = _largest_files_query(storage_service_id, file_type, limit)
-
-    for file_ in files:
-        file_info = {}
-
-        file_info["id"] = file_.id
-        file_info[FIELD_UUID] = file_.uuid
-        file_info[FIELD_NAME] = file_.name
-        file_info[FIELD_SIZE] = int(file_.size)
-        file_info[FIELD_AIP_ID] = file_.aip_id
-        file_info[FIELD_FILE_TYPE] = file_.file_type.value
-
-        try:
-            file_info[FIELD_FORMAT] = file_.file_format
-        except AttributeError:
-            pass
-        try:
-            file_info[FIELD_VERSION] = file_.format_version
-        except AttributeError:
-            pass
-        try:
-            file_info[FIELD_PUID] = file_.puid
-        except AttributeError:
-            pass
-
-        matching_aip = AIP.query.get(file_.aip_id)
-        if matching_aip is not None:
-            file_info[FIELD_AIP_NAME] = matching_aip.transfer_name
-            file_info[FIELD_AIP_UUID] = matching_aip.uuid
-
-        report[FIELD_FILES].append(file_info)
-
-    return report
-
-
-def _query_aips_by_file_format_or_puid(
-    storage_service_id, search_string, original_files=True, file_format=True
-):
-    """Fetch information on all AIPs with given format or PUID from db.
-
-    :param storage_service_id: Storage Service ID (int)
-    :param search_string: File format or PUID (str)
-    :param original_files: Flag indicating whether returned data
-    describes original (default) or preservation files (bool)
-    :param file_format: Flag indicating whether to filter on file
-    format (default) or PUID (bool)
-
-    :returns: SQLAlchemy query results
-    """
-    AIP_ID = "id"
-    TRANSFER_NAME = "name"
-    AIP_UUID = "uuid"
-    FILE_COUNT = "file_count"
-    FILE_SIZE = "total_size"
-    aips = (
-        db.session.query(
-            AIP.id.label(AIP_ID),
-            AIP.transfer_name.label(TRANSFER_NAME),
-            AIP.uuid.label(AIP_UUID),
-            db.func.count(File.id).label(FILE_COUNT),
-            db.func.sum(File.size).label(FILE_SIZE),
-        )
-        .join(File)
-        .join(StorageService)
-        .filter(StorageService.id == storage_service_id)
-        .group_by(AIP.id)
-        .order_by(db.func.count(File.id).desc(), db.func.sum(File.size).desc())
-    )
-
-    if original_files is False:
-        aips = aips.filter(File.file_type == FileType.preservation.value)
-    else:
-        aips = aips.filter(File.file_type == FileType.original.value)
-
-    if file_format:
-        return aips.filter(File.file_format == search_string)
-    return aips.filter(File.puid == search_string)
-
-
-def _aips_by_file_format_or_puid(
-    storage_service_id, search_string, original_files=True, file_format=True
-):
-    """Return overview of all AIPs containing original files in format
-
-    :param storage_service_id: Storage Service ID (int)
-    :param search_string: File format name or PUID (str)
-    :param original_files: Flag indicating whether returned data
-    describes original (default) or preservation files (bool)
-    :param file_format: Flag indicating whether to filter on file
-    format (default) or PUID (bool)
-
-    :returns: "report" dict containing following fields:
-        report["StorageName"]: Name of Storage Service queried
-        report["AIPs"]: List of result AIPs ordered desc by count
-    """
-    report = {}
-
-    storage_service = _get_storage_service(storage_service_id)
-    report[FIELD_STORAGE_NAME] = storage_service.name
-
-    if file_format:
-        report[FIELD_FORMAT] = search_string
-    else:
-        report[FIELD_PUID] = search_string
-
-    report[FIELD_AIPS] = []
-    results = _query_aips_by_file_format_or_puid(
-        storage_service_id, search_string, original_files, file_format
-    )
-    for result in results:
-        aip_info = {}
-
-        aip_info["id"] = result.id
-        aip_info[FIELD_AIP_NAME] = result.name
-        aip_info[FIELD_UUID] = result.uuid
-        aip_info[FIELD_COUNT] = result.file_count
-        aip_info[FIELD_SIZE] = result.total_size
-
-        report[FIELD_AIPS].append(aip_info)
-
-    return report
-
-
-def aips_by_file_format(storage_service_id, file_format, original_files=True):
-    """Return overview of AIPs containing original files in format.
-
-    :param storage_service_id: Storage Service ID (int)
-    :param file_format: File format name (str)
-    :param original_files: Flag indicating whether returned data
-    describes original (default) or preservation files (bool)
-
-    :returns: Report dict provided by _aips_by_file_format_or_puid
-    """
-    return _aips_by_file_format_or_puid(
-        storage_service_id=storage_service_id,
-        search_string=file_format,
-        original_files=original_files,
-    )
-
-
-def aips_by_puid(storage_service_id, puid, original_files=True):
-    """Return overview of AIPs containing original files in format.
-
-    :param storage_service_id: Storage Service ID (int)
-    :param puid: PUID (str)
-    :param original_files: Flag indicating whether returned data
-    describes original (default) or preservation files (bool)
-
-    :returns: Report dict provided by _aips_by_file_format_or_puid
-    """
-    return _aips_by_file_format_or_puid(
-        storage_service_id=storage_service_id,
-        search_string=puid,
-        original_files=original_files,
-        file_format=False,
-    )
-
-
-def agents_transfers(storage_service_id):
-    """Return information about agents involved in creating a transfer
-    and provide some simple statistics, e.g. ingest start time and
-    ingest finish time.
-    """
-    report = {}
-    ingests = []
-
-    storage_service = _get_storage_service(storage_service_id)
-
-    try:
-        report[FIELD_STORAGE_NAME] = storage_service.name
-    except AttributeError:
-        # No storage service has been returned and so we have nothing
-        # to return.
-        report[FIELD_STORAGE_NAME] = None
-        report[FIELD_INGESTS] = ingests
-        return report
-
-    aips = AIP.query.filter_by(storage_service_id=storage_service.id).all()
-
-    EVENT_TYPE = "ingestion"
-    AGENT_TYPE = "Archivematica user"
-
-    for aip in aips:
-        event = (
-            db.session.query(Event)
-            .join(File)
-            .filter(File.aip_id == aip.id, Event.type == EVENT_TYPE)
-            .first()
-        )
-        log_line = {}
-        log_line[FIELD_AIP_UUID] = aip.uuid
-        log_line[FIELD_AIP_NAME] = aip.transfer_name
-        log_line[FIELD_INGEST_START_DATE] = str(event.date)
-        log_line[FIELD_INGEST_FINISH_DATE] = str(aip.create_date)
-        for agent in event.event_agents:
-            if agent.agent_type == AGENT_TYPE:
-                log_line[FIELD_USER] = _get_username(agent.agent_value)
-        ingests.append(log_line)
-    report[FIELD_INGESTS] = ingests
     return report

--- a/AIPscan/Data/fields.py
+++ b/AIPscan/Data/fields.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+"""Field name constants."""
+
+FIELD_AIP_ID = "AIPID"
+FIELD_AIP_NAME = "AIPName"
+FIELD_AIP_SIZE = "AIPSize"
+FIELD_AIP_UUID = "AIPUUID"
+FIELD_AIPS = "AIPs"
+FIELD_ALL_AIPS = "AllAIPs"
+
+FIELD_COUNT = "Count"
+FIELD_CREATED_DATE = "CreatedDate"
+
+FIELD_DERIVATIVE_COUNT = "DerivativeCount"
+FIELD_DERIVATIVE_FORMAT = "DerivativeFormat"
+FIELD_DERIVATIVE_UUID = "DerivativeUUID"
+
+FIELD_EVENT = "Event"
+
+FIELD_FILES = "Files"
+FIELD_FILE_COUNT = "FileCount"
+FIELD_FILE_TYPE = "FileType"
+FIELD_FILENAME = "Filename"
+FIELD_FORMAT = "Format"
+FIELD_FORMATS = "Formats"
+FIELD_FORMAT_VERSIONS = "FormatVersions"
+
+FIELD_INGESTS = "Ingests"
+FIELD_INGEST_START_DATE = "IngestStartDate"
+FIELD_INGEST_FINISH_DATE = "IngestFinishDate"
+
+FIELD_NAME = "Name"
+
+FIELD_ORIGINAL_UUID = "OriginalUUID"
+FIELD_ORIGINAL_FORMAT = "OriginalFormat"
+
+FIELD_PUID = "PUID"
+
+FIELD_RELATED_PAIRING = "RelatedPairing"
+
+FIELD_SIZE = "Size"
+FIELD_STORAGE_NAME = "StorageName"
+
+FIELD_TRANSFER_NAME = "TransferName"
+
+FIELD_USER = "User"
+FIELD_UUID = "UUID"
+
+FIELD_VERSION = "Version"

--- a/AIPscan/Data/report_data.py
+++ b/AIPscan/Data/report_data.py
@@ -1,0 +1,344 @@
+# -*- coding: utf-8 -*-
+
+"""Data endpoints optimized for reports in the Reporter blueprint."""
+
+from AIPscan import db
+from AIPscan.Data import _get_storage_service, fields
+from AIPscan.models import AIP, Event, File, FileType, StorageService
+
+
+VALID_FILE_TYPES = set(item.value for item in FileType)
+
+
+def _get_username(agent_string):
+    """Retrieve username from the standard agent string stored in the
+    database, normally formatted as:
+
+        * username="test", first_name="", last_name=""
+    """
+    USERNAME = "username="
+    return agent_string.split(",", 1)[0].replace(USERNAME, "").replace('"', "")
+
+
+def _format_versions_count_query(storage_service_id, start_date, end_date):
+    """Fetch information from database on format versions.
+
+    :param storage_service_id: Storage Service ID (int)
+    :start_date: Inclusive AIP creation start date
+        (datetime.datetime object)
+    :end_date: Inclusive AIP creation end date
+        (datetime.datetime object)
+
+    :returns: SQLAlchemy query results
+    """
+    PUID = "puid"
+    FILE_FORMAT = "file_format"
+    FORMAT_VERSION = "format_version"
+    FILE_COUNT = "file_count"
+    FILE_SIZE = "total_size"
+
+    return (
+        db.session.query(
+            File.puid.label(PUID),
+            File.file_format.label(FILE_FORMAT),
+            File.format_version.label(FORMAT_VERSION),
+            db.func.count(File.id).label(FILE_COUNT),
+            db.func.sum(File.size).label(FILE_SIZE),
+        )
+        .join(AIP)
+        .join(StorageService)
+        .filter(StorageService.id == storage_service_id)
+        .filter(File.file_type == FileType.original.value)
+        .filter(AIP.create_date >= start_date)
+        .filter(AIP.create_date < end_date)
+        .group_by(File.puid)
+        .order_by(db.func.count(File.id).desc(), db.func.sum(File.size).desc())
+    )
+
+
+def format_versions_count(storage_service_id, start_date, end_date):
+    """Return a summary of format versions in Storage Service.
+
+    :param storage_service_id: Storage Service ID (int)
+    :start_date: Inclusive AIP creation start date
+        (datetime.datetime object)
+    :end_date: Inclusive AIP creation end date
+        (datetime.datetime object)
+
+    :returns: "report" dict containing following fields:
+        report["StorageName"]: Name of Storage Service queried
+        report["FormatVersions"]: List of result files ordered desc by size
+    """
+    report = {}
+    report[fields.FIELD_FORMAT_VERSIONS] = []
+    report[fields.FIELD_STORAGE_NAME] = None
+
+    storage_service = _get_storage_service(storage_service_id)
+    if storage_service is not None:
+        report[fields.FIELD_STORAGE_NAME] = storage_service.name
+
+    versions = _format_versions_count_query(storage_service_id, start_date, end_date)
+
+    for version in versions:
+        version_info = {}
+
+        version_info[fields.FIELD_PUID] = version.puid
+        version_info[fields.FIELD_FORMAT] = version.file_format
+        version_info[fields.FIELD_COUNT] = version.file_count
+
+        try:
+            version_info[fields.FIELD_VERSION] = version.format_version
+        except AttributeError:
+            pass
+
+        version_info[fields.FIELD_SIZE] = 0
+        if version.total_size is not None:
+            version_info[fields.FIELD_SIZE] = version.total_size
+
+        report[fields.FIELD_FORMAT_VERSIONS].append(version_info)
+
+    return report
+
+
+def _largest_files_query(storage_service_id, file_type, limit):
+    """Fetch file information from database for largest files query
+
+    This is separated into its own helper function to aid in testing.
+    """
+    if file_type is not None and file_type in VALID_FILE_TYPES:
+        files = (
+            File.query.join(AIP)
+            .join(StorageService)
+            .filter(StorageService.id == storage_service_id)
+            .filter(File.file_type == file_type)
+            .order_by(File.size.desc())
+            .limit(limit)
+        )
+    else:
+        files = (
+            File.query.join(AIP)
+            .join(StorageService)
+            .filter(StorageService.id == storage_service_id)
+            .order_by(File.size.desc())
+            .limit(limit)
+        )
+    return files
+
+
+def largest_files(storage_service_id, file_type=None, limit=20):
+    """Return a summary of the largest files in a given Storage Service
+
+    :param storage_service_id: Storage Service ID
+    :param file_type: Optional filter for type of file to return
+        (acceptable values are "original" or "preservation")
+    :param limit: Upper limit of number of results to return
+
+    :returns: "report" dict containing following fields:
+        report["StorageName"]: Name of Storage Service queried
+        report["Files"]: List of result files ordered desc by size
+    """
+    report = {}
+    report[fields.FIELD_FILES] = []
+    storage_service = _get_storage_service(storage_service_id)
+    report[fields.FIELD_STORAGE_NAME] = storage_service.name
+
+    files = _largest_files_query(storage_service_id, file_type, limit)
+
+    for file_ in files:
+        file_info = {}
+
+        file_info["id"] = file_.id
+        file_info[fields.FIELD_UUID] = file_.uuid
+        file_info[fields.FIELD_NAME] = file_.name
+        file_info[fields.FIELD_SIZE] = int(file_.size)
+        file_info[fields.FIELD_AIP_ID] = file_.aip_id
+        file_info[fields.FIELD_FILE_TYPE] = file_.file_type.value
+
+        try:
+            file_info[fields.FIELD_FORMAT] = file_.file_format
+        except AttributeError:
+            pass
+        try:
+            file_info[fields.FIELD_VERSION] = file_.format_version
+        except AttributeError:
+            pass
+        try:
+            file_info[fields.FIELD_PUID] = file_.puid
+        except AttributeError:
+            pass
+
+        matching_aip = AIP.query.get(file_.aip_id)
+        if matching_aip is not None:
+            file_info[fields.FIELD_AIP_NAME] = matching_aip.transfer_name
+            file_info[fields.FIELD_AIP_UUID] = matching_aip.uuid
+
+        report[fields.FIELD_FILES].append(file_info)
+
+    return report
+
+
+def _query_aips_by_file_format_or_puid(
+    storage_service_id, search_string, original_files=True, file_format=True
+):
+    """Fetch information on all AIPs with given format or PUID from db.
+
+    :param storage_service_id: Storage Service ID (int)
+    :param search_string: File format or PUID (str)
+    :param original_files: Flag indicating whether returned data
+        describes original (default) or preservation files (bool)
+    :param file_format: Flag indicating whether to filter on file
+        format (default) or PUID (bool)
+
+    :returns: SQLAlchemy query results
+    """
+    AIP_ID = "id"
+    TRANSFER_NAME = "name"
+    AIP_UUID = "uuid"
+    FILE_COUNT = "file_count"
+    FILE_SIZE = "total_size"
+    aips = (
+        db.session.query(
+            AIP.id.label(AIP_ID),
+            AIP.transfer_name.label(TRANSFER_NAME),
+            AIP.uuid.label(AIP_UUID),
+            db.func.count(File.id).label(FILE_COUNT),
+            db.func.sum(File.size).label(FILE_SIZE),
+        )
+        .join(File)
+        .join(StorageService)
+        .filter(StorageService.id == storage_service_id)
+        .group_by(AIP.id)
+        .order_by(db.func.count(File.id).desc(), db.func.sum(File.size).desc())
+    )
+
+    if original_files is False:
+        aips = aips.filter(File.file_type == FileType.preservation.value)
+    else:
+        aips = aips.filter(File.file_type == FileType.original.value)
+
+    if file_format:
+        return aips.filter(File.file_format == search_string)
+    return aips.filter(File.puid == search_string)
+
+
+def _aips_by_file_format_or_puid(
+    storage_service_id, search_string, original_files=True, file_format=True
+):
+    """Return overview of all AIPs containing original files in format
+
+    :param storage_service_id: Storage Service ID (int)
+    :param search_string: File format name or PUID (str)
+    :param original_files: Flag indicating whether returned data
+        data describes original (default) or preservation files (bool)
+    :param file_format: Flag indicating whether to filter on file
+        file format (default) or PUID (bool)
+
+    :returns: "report" dict containing following fields:
+        report["StorageName"]: Name of Storage Service queried
+        report["AIPs"]: List of result AIPs ordered desc by count
+    """
+    report = {}
+
+    storage_service = _get_storage_service(storage_service_id)
+    report[fields.FIELD_STORAGE_NAME] = storage_service.name
+
+    if file_format:
+        report[fields.FIELD_FORMAT] = search_string
+    else:
+        report[fields.FIELD_PUID] = search_string
+
+    report[fields.FIELD_AIPS] = []
+    results = _query_aips_by_file_format_or_puid(
+        storage_service_id, search_string, original_files, file_format
+    )
+    for result in results:
+        aip_info = {}
+
+        aip_info["id"] = result.id
+        aip_info[fields.FIELD_AIP_NAME] = result.name
+        aip_info[fields.FIELD_UUID] = result.uuid
+        aip_info[fields.FIELD_COUNT] = result.file_count
+        aip_info[fields.FIELD_SIZE] = result.total_size
+
+        report[fields.FIELD_AIPS].append(aip_info)
+
+    return report
+
+
+def aips_by_file_format(storage_service_id, file_format, original_files=True):
+    """Return overview of AIPs containing original files in format.
+
+    :param storage_service_id: Storage Service ID (int)
+    :param file_format: File format name (str)
+    :param original_files: Flag indicating whether returned data
+        describes original (default) or preservation files (bool)
+
+    :returns: Report dict provided by _aips_by_file_format_or_puid
+    """
+    return _aips_by_file_format_or_puid(
+        storage_service_id=storage_service_id,
+        search_string=file_format,
+        original_files=original_files,
+    )
+
+
+def aips_by_puid(storage_service_id, puid, original_files=True):
+    """Return overview of AIPs containing original files in format.
+
+    :param storage_service_id: Storage Service ID (int)
+    :param puid: PUID (str)
+    :param original_files: Flag indicating whether returned data
+        describes original (default) or preservation files (bool)
+
+    :returns: Report dict provided by _aips_by_file_format_or_puid
+    """
+    return _aips_by_file_format_or_puid(
+        storage_service_id=storage_service_id,
+        search_string=puid,
+        original_files=original_files,
+        file_format=False,
+    )
+
+
+def agents_transfers(storage_service_id):
+    """Return information about agents involved in creating a transfer
+    and provide some simple statistics, e.g. ingest start time and
+    ingest finish time.
+    """
+    report = {}
+    ingests = []
+
+    storage_service = _get_storage_service(storage_service_id)
+
+    try:
+        report[fields.FIELD_STORAGE_NAME] = storage_service.name
+    except AttributeError:
+        # No storage service has been returned and so we have nothing
+        # to return.
+        report[fields.FIELD_STORAGE_NAME] = None
+        report[fields.FIELD_INGESTS] = ingests
+        return report
+
+    aips = AIP.query.filter_by(storage_service_id=storage_service.id).all()
+
+    EVENT_TYPE = "ingestion"
+    AGENT_TYPE = "Archivematica user"
+
+    for aip in aips:
+        event = (
+            db.session.query(Event)
+            .join(File)
+            .filter(File.aip_id == aip.id, Event.type == EVENT_TYPE)
+            .first()
+        )
+        log_line = {}
+        log_line[fields.FIELD_AIP_UUID] = aip.uuid
+        log_line[fields.FIELD_AIP_NAME] = aip.transfer_name
+        log_line[fields.FIELD_INGEST_START_DATE] = str(event.date)
+        log_line[fields.FIELD_INGEST_FINISH_DATE] = str(aip.create_date)
+        for agent in event.event_agents:
+            if agent.agent_type == AGENT_TYPE:
+                log_line[fields.FIELD_USER] = _get_username(agent.agent_value)
+        ingests.append(log_line)
+    report[fields.FIELD_INGESTS] = ingests
+    return report

--- a/AIPscan/Data/tests/conftest.py
+++ b/AIPscan/Data/tests/conftest.py
@@ -3,6 +3,8 @@
 """This module defines shared Data blueprint pytest fixtures."""
 
 from datetime import datetime
+import uuid
+
 import pytest
 
 from AIPscan import db, create_app
@@ -11,9 +13,9 @@ from AIPscan.models import (
     AIP,
     Event,
     EventAgent,
-    FetchJob,
     File,
     FileType,
+    FetchJob,
     StorageService,
 )
 
@@ -21,19 +23,141 @@ from AIPscan.models import (
 TIFF_FILE_FORMAT = "Tagged Image File Format"
 TIFF_PUID = "fmt/353"
 
+JPEG_FILE_FORMAT = "JPEG"
+
+JPEG_1_01_FORMAT_VERSION = "1.01"
+JPEG_1_01_PUID = "fmt/43"
+
+JPEG_1_02_FORMAT_VERSION = "1.02"
+JPEG_1_02_PUID = "fmt/44"
+
 ORIGINAL_FILE_SIZE = 1000
 PRESERVATION_FILE_SIZE = 2000
 
+AIP_1_CREATION_DATE = "2020-01-01"
+AIP_2_CREATION_DATE = "2020-06-01"
 
-def _datetime_obj_from_string(date_string):
+
+def _datetime_obj_from_string(date_string, date_only=False):
     """Return a datetime object from a given string to aid in the
     assignment of consistent and reliable test dates.
     """
-    return datetime.strptime(date_string, "%Y-%m-%d %H:%M:%S")
+    str_format = "%Y-%m-%d %H:%M:%S"
+    if date_only is True:
+        str_format = "%Y-%m-%d"
+
+    return datetime.strptime(date_string, str_format)
 
 
 INGEST_EVENT_CREATION_TIME = _datetime_obj_from_string("2020-12-02 10:00:00")
 AIP_CREATION_TIME = _datetime_obj_from_string("2020-12-02 10:30:32")
+
+
+def _add_test_object_to_db(test_object):
+    """Add and commit test object to database."""
+    db.session.add(test_object)
+    db.session.commit()
+
+
+def _create_test_storage_service(**kwargs):
+    """Create and return a Storage Service with overridable defaults."""
+    storage_service = StorageService(
+        name=kwargs.get("name", "test storage service"),
+        url=kwargs.get("name", "http://example.com"),
+        user_name=kwargs.get("user_name", "test"),
+        api_key=kwargs.get("api_key", "test"),
+        download_limit=kwargs.get("download_limit", 0),
+        download_offset=kwargs.get("download_offset", 10),
+        default=kwargs.get("default", True),
+    )
+    _add_test_object_to_db(storage_service)
+    return storage_service
+
+
+def _create_test_fetch_job(**kwargs):
+    """Create and return a test Fetch Job with overridable defaults."""
+    fetch_job = FetchJob(
+        total_packages=kwargs.get("total_packages", 1),
+        total_aips=kwargs.get("total_aips", 1),
+        total_deleted_aips=kwargs.get("total_deleted_aips", 0),
+        download_start=kwargs.get("download_start", datetime.now()),
+        download_end=kwargs.get("download_end", datetime.now()),
+        download_directory=kwargs.get("download_directory", "/some/directory/"),
+        storage_service_id=kwargs.get("storage_service_id", 1),
+    )
+    _add_test_object_to_db(fetch_job)
+    return fetch_job
+
+
+def _create_test_aip(**kwargs):
+    """Create and return a test AIP with overridable defaults."""
+    aip = AIP(
+        uuid=kwargs.get("uuid", str(uuid.uuid4())),
+        transfer_name=kwargs.get("transfer_name", "Test AIP"),
+        create_date=kwargs.get("create_date", datetime.now()),
+        storage_service_id=kwargs.get("storage_service_id", 1),
+        fetch_job_id=kwargs.get("fetch_job_id", 1),
+    )
+    _add_test_object_to_db(aip)
+    return aip
+
+
+def _create_test_file(**kwargs):
+    """Create and return a test File with overridable defaults."""
+    file_ = File(
+        name=kwargs.get("name", "file_name.ext"),
+        filepath=kwargs.get("filepath", "/path/to/file_name.ext"),
+        uuid=kwargs.get("uuid", str(uuid.uuid4())),
+        file_type=kwargs.get("file_type", FileType.original),
+        size=kwargs.get("size", 0),
+        date_created=kwargs.get("date_created", datetime.now()),
+        puid=kwargs.get("puid", "fmt/test-1"),
+        file_format=kwargs.get("file_format", "ACME File Format"),
+        format_version=kwargs.get("format_version", "0.0.0"),
+        checksum_type=kwargs.get("checksum_type", "test"),
+        checksum_value=kwargs.get("checksum_value", "test"),
+        aip_id=kwargs.get("aip_id", 1),
+    )
+    _add_test_object_to_db(file_)
+    return file_
+
+
+def _create_test_agent(**kwargs):
+    """Create and return a test Agent with overridable defaults."""
+    agent = Agent(
+        linking_type_value=kwargs.get("linking_type_value", "Archivematica user pk-1"),
+        agent_type=kwargs.get("agent_type", "Archivematica user"),
+        agent_value=kwargs.get(
+            "agent_value", 'username="user one", first_name="", last_name=""'
+        ),
+    )
+    _add_test_object_to_db(agent)
+    return agent
+
+
+def _create_test_event(**kwargs):
+    """Create and return a test Event with overridable defaults."""
+    event = Event(
+        type=kwargs.get("type", "ingestion"),
+        uuid=kwargs.get("uuid", str(uuid.uuid4())),
+        date=kwargs.get("date", datetime.now()),
+        detail=kwargs.get("detail", "ingestion detail"),
+        outcome=kwargs.get("outcome", "success"),
+        outcome_detail=kwargs.get("outcome_detail", "outcome detail"),
+        file_id=kwargs.get("file_id", 1),
+    )
+    _add_test_object_to_db(event)
+    return event
+
+
+def _create_test_event_agent(**kwargs):
+    """Create and return a test EventAgent relationship with overridable defaults."""
+    event_relationship = EventAgent.insert().values(
+        event_id=kwargs.get("event_id", 1), agent_id=kwargs.get("agent_id", 1)
+    )
+    db.session.execute(event_relationship)
+    db.session.commit()
+    return event_relationship
 
 
 @pytest.fixture
@@ -47,97 +171,94 @@ def app_with_populated_files(scope="package"):
     with app.app_context():
         db.create_all()
 
-        storage_service = StorageService(
-            name="test storage service",
-            url="http://example.com",
-            user_name="test",
-            api_key="test",
-            download_limit=20,
-            download_offset=10,
-            default=True,
-        )
-        db.session.add(storage_service)
-        db.session.commit()
+        storage_service = _create_test_storage_service()
+        fetch_job = _create_test_fetch_job(storage_service_id=storage_service.id)
 
-        fetch_job = FetchJob(
-            total_packages=1,
-            total_aips=1,
-            total_deleted_aips=0,
-            download_start=datetime.now(),
-            download_end=datetime.now(),
-            download_directory="/some/dir",
-            storage_service_id=storage_service.id,
-        )
-        db.session.add(fetch_job)
-        db.session.commit()
-
-        aip = AIP(
+        _ = _create_test_aip(
             uuid="111111111111-1111-1111-11111111",
-            transfer_name="test aip",
             create_date=AIP_CREATION_TIME,
             storage_service_id=storage_service.id,
             fetch_job_id=fetch_job.id,
         )
-        db.session.add(aip)
-        db.session.commit()
 
-        original_file = File(
-            name="original.tif",
-            filepath="/path/to/original.tif",
-            uuid="111111111111-1111-1111-11111111",
+        original_file = _create_test_file(
             file_type=FileType.original,
             size=ORIGINAL_FILE_SIZE,
-            date_created=datetime.now(),
             puid=TIFF_PUID,
             file_format=TIFF_FILE_FORMAT,
-            checksum_type="test",
-            checksum_value="test",
-            aip_id=1,
         )
-        preservation_file = File(
-            name="preservation.tif",
-            filepath="/path/to/preservation.tif",
-            uuid="222222222222-2222-2222-22222222",
+
+        _ = _create_test_file(
             file_type=FileType.preservation,
             size=PRESERVATION_FILE_SIZE,
-            date_created=datetime.now(),
             puid=TIFF_PUID,
             file_format=TIFF_FILE_FORMAT,
-            checksum_type="test",
-            checksum_value="test",
-            aip_id=1,
-        )
-        db.session.add(preservation_file)
-        db.session.add(original_file)
-        db.session.commit()
-
-        user_agent = Agent(
-            linking_type_value="Archivematica user pk-1",
-            agent_type="Archivematica user",
-            agent_value='username="user one", first_name="", last_name=""',
         )
 
-        event = Event(
-            type="ingestion",
-            uuid="333333333333-3333-3333-33333333",
-            date=INGEST_EVENT_CREATION_TIME,
-            detail="ingestion detail",
-            outcome="success",
-            outcome_detail="outcome detail",
-            file_id=original_file.id,
+        user_agent = _create_test_agent()
+
+        event = _create_test_event(
+            type="ingestion", date=INGEST_EVENT_CREATION_TIME, file_id=original_file.id
         )
 
-        db.session.add(user_agent)
-        db.session.add(event)
+        _ = _create_test_event_agent(event_id=event.id, agent_id=user_agent.id)
 
-        db.session.commit()
+        yield app
 
-        event_relationship = EventAgent.insert().values(
-            event_id=event.id, agent_id=user_agent.id
+        db.drop_all()
+
+
+@pytest.fixture
+def app_with_populated_format_versions(scope="package"):
+    """Fixture with pre-populated data.
+
+    This fixture is used to create expected state which is then used to
+    test the Data.format_versions_count endpoint.
+    """
+    AIP_DATE_FORMAT = "%Y-%m-%d"
+
+    app = create_app("test")
+    with app.app_context():
+        db.create_all()
+
+        storage_service = _create_test_storage_service()
+        fetch_job = _create_test_fetch_job(storage_service_id=storage_service.id)
+
+        aip1 = _create_test_aip(
+            create_date=datetime.strptime(AIP_1_CREATION_DATE, AIP_DATE_FORMAT),
+            storage_service_id=storage_service.id,
+            fetch_job_id=fetch_job.id,
         )
 
-        db.session.execute(event_relationship)
-        db.session.commit()
+        aip2 = _create_test_aip(
+            create_date=datetime.strptime(AIP_2_CREATION_DATE, AIP_DATE_FORMAT),
+            storage_service_id=storage_service.id,
+            fetch_job_id=fetch_job.id,
+        )
+
+        _ = _create_test_file(
+            size=ORIGINAL_FILE_SIZE,
+            puid=JPEG_1_01_PUID,
+            file_format=JPEG_FILE_FORMAT,
+            format_version=JPEG_1_01_FORMAT_VERSION,
+            aip_id=aip1.id,
+        )
+
+        _ = _create_test_file(
+            size=PRESERVATION_FILE_SIZE,
+            puid=JPEG_1_02_PUID,
+            file_format=JPEG_FILE_FORMAT,
+            format_version=JPEG_1_02_FORMAT_VERSION,
+            aip_id=aip2.id,
+        )
+
+        _ = _create_test_file(
+            size=None,
+            puid="fmt/468",
+            file_format="ISO Disk Image File",
+            format_version=None,
+            aip_id=aip2.id,
+        )
 
         yield app
 

--- a/AIPscan/Data/tests/test_agents_transfers.py
+++ b/AIPscan/Data/tests/test_agents_transfers.py
@@ -6,7 +6,7 @@ the ingest log report and agents-transfers API endpoint.
 
 import pytest
 
-from AIPscan.Data import data
+from AIPscan.Data import report_data
 from AIPscan.Data.tests.conftest import INGEST_EVENT_CREATION_TIME, AIP_CREATION_TIME
 
 
@@ -41,7 +41,7 @@ def test_agents_transfers(
 ):
     """Test that structure of agents-transfers matches expectations."""
 
-    report = data.agents_transfers(storage_service_id=storage_id)
+    report = report_data.agents_transfers(storage_service_id=storage_id)
 
     assert report["StorageName"] == storage_name
     assert len(report["Ingests"]) == number_of_ingests

--- a/AIPscan/Data/tests/test_aips_by_format.py
+++ b/AIPscan/Data/tests/test_aips_by_format.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from AIPscan.Data import data
+from AIPscan.Data import fields, report_data
 from AIPscan.Data.tests import (
     MOCK_AIPS_BY_FORMAT_OR_PUID_QUERY_RESULTS as MOCK_QUERY_RESULTS,
     MOCK_STORAGE_SERVICE,
@@ -30,15 +30,19 @@ from AIPscan.Data.tests.conftest import (
 )
 def test_aips_by_file_format(app_instance, mocker, query_results, results_count):
     """Test that results match high-level expectations."""
-    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query = mocker.patch(
+        "AIPscan.Data.report_data._query_aips_by_file_format_or_puid"
+    )
     mock_query.return_value = query_results
 
-    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
     mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
-    report = data.aips_by_file_format(MOCK_STORAGE_SERVICE_ID, "Some file format")
-    assert report[data.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
-    assert len(report[data.FIELD_AIPS]) == results_count
+    report = report_data.aips_by_file_format(
+        MOCK_STORAGE_SERVICE_ID, "Some file format"
+    )
+    assert report[fields.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
+    assert len(report[fields.FIELD_AIPS]) == results_count
 
 
 @pytest.mark.parametrize(
@@ -46,20 +50,24 @@ def test_aips_by_file_format(app_instance, mocker, query_results, results_count)
 )
 def test_aips_by_file_format_aip_elements(app_instance, mocker, test_aip):
     """Test that structure of AIP data matches expectations."""
-    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query = mocker.patch(
+        "AIPscan.Data.report_data._query_aips_by_file_format_or_puid"
+    )
     mock_query.return_value = [test_aip]
 
-    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
     mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
-    report = data.aips_by_file_format(MOCK_STORAGE_SERVICE_ID, "Some file format")
-    report_aip = report[data.FIELD_AIPS][0]
+    report = report_data.aips_by_file_format(
+        MOCK_STORAGE_SERVICE_ID, "Some file format"
+    )
+    report_aip = report[fields.FIELD_AIPS][0]
 
     assert test_aip.id == report_aip.get("id")
-    assert test_aip.name == report_aip.get(data.FIELD_AIP_NAME)
-    assert test_aip.uuid == report_aip.get(data.FIELD_UUID)
-    assert test_aip.file_count == report_aip.get(data.FIELD_COUNT)
-    assert test_aip.total_size == report_aip.get(data.FIELD_SIZE)
+    assert test_aip.name == report_aip.get(fields.FIELD_AIP_NAME)
+    assert test_aip.uuid == report_aip.get(fields.FIELD_UUID)
+    assert test_aip.file_count == report_aip.get(fields.FIELD_COUNT)
+    assert test_aip.total_size == report_aip.get(fields.FIELD_SIZE)
 
 
 @pytest.mark.parametrize(
@@ -97,10 +105,10 @@ def test_aips_by_file_format_contents(
     This integration test uses a pre-populated fixture to verify that
     the database access layer of our endpoint returns what we expect.
     """
-    results = data.aips_by_file_format(
+    results = report_data.aips_by_file_format(
         storage_service_id=1, file_format=format_name, original_files=original_files
     )
-    aips = results[data.FIELD_AIPS]
+    aips = results[fields.FIELD_AIPS]
     assert len(aips) == aip_count
-    assert sum(aip[data.FIELD_COUNT] for aip in aips) == total_file_count
-    assert sum(aip[data.FIELD_SIZE] for aip in aips) == total_file_size
+    assert sum(aip[fields.FIELD_COUNT] for aip in aips) == total_file_count
+    assert sum(aip[fields.FIELD_SIZE] for aip in aips) == total_file_size

--- a/AIPscan/Data/tests/test_aips_by_puid.py
+++ b/AIPscan/Data/tests/test_aips_by_puid.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from AIPscan.Data import data
+from AIPscan.Data import fields, report_data
 from AIPscan.Data.tests import (
     MOCK_AIPS_BY_FORMAT_OR_PUID_QUERY_RESULTS as MOCK_QUERY_RESULTS,
     MOCK_STORAGE_SERVICE,
@@ -30,15 +30,17 @@ from AIPscan.Data.tests.conftest import (
 )
 def test_aips_by_puid(app_instance, mocker, query_results, results_count):
     """Test that results match high-level expectations."""
-    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query = mocker.patch(
+        "AIPscan.Data.report_data._query_aips_by_file_format_or_puid"
+    )
     mock_query.return_value = query_results
 
-    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
     mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
-    report = data.aips_by_puid(MOCK_STORAGE_SERVICE_ID, "fmt/###")
-    assert report[data.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
-    assert len(report[data.FIELD_AIPS]) == results_count
+    report = report_data.aips_by_puid(MOCK_STORAGE_SERVICE_ID, "fmt/###")
+    assert report[fields.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
+    assert len(report[fields.FIELD_AIPS]) == results_count
 
 
 @pytest.mark.parametrize(
@@ -46,20 +48,22 @@ def test_aips_by_puid(app_instance, mocker, query_results, results_count):
 )
 def test_aips_by_puid_aip_elements(app_instance, mocker, test_aip):
     """Test that structure of AIP data matches expectations."""
-    mock_query = mocker.patch("AIPscan.Data.data._query_aips_by_file_format_or_puid")
+    mock_query = mocker.patch(
+        "AIPscan.Data.report_data._query_aips_by_file_format_or_puid"
+    )
     mock_query.return_value = [test_aip]
 
-    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
     mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
-    report = data.aips_by_puid(MOCK_STORAGE_SERVICE_ID, "fmt/###")
-    report_aip = report[data.FIELD_AIPS][0]
+    report = report_data.aips_by_puid(MOCK_STORAGE_SERVICE_ID, "fmt/###")
+    report_aip = report[fields.FIELD_AIPS][0]
 
     assert test_aip.id == report_aip.get("id")
-    assert test_aip.name == report_aip.get(data.FIELD_AIP_NAME)
-    assert test_aip.uuid == report_aip.get(data.FIELD_UUID)
-    assert test_aip.file_count == report_aip.get(data.FIELD_COUNT)
-    assert test_aip.total_size == report_aip.get(data.FIELD_SIZE)
+    assert test_aip.name == report_aip.get(fields.FIELD_AIP_NAME)
+    assert test_aip.uuid == report_aip.get(fields.FIELD_UUID)
+    assert test_aip.file_count == report_aip.get(fields.FIELD_COUNT)
+    assert test_aip.total_size == report_aip.get(fields.FIELD_SIZE)
 
 
 @pytest.mark.parametrize(
@@ -97,10 +101,10 @@ def test_aips_by_file_format_contents(
     This integration test uses a pre-populated fixture to verify that
     the database access layer of our endpoint returns what we expect.
     """
-    results = data.aips_by_puid(
+    results = report_data.aips_by_puid(
         storage_service_id=1, puid=puid, original_files=original_files
     )
-    aips = results[data.FIELD_AIPS]
+    aips = results[fields.FIELD_AIPS]
     assert len(aips) == aip_count
-    assert sum(aip[data.FIELD_COUNT] for aip in aips) == total_file_count
-    assert sum(aip[data.FIELD_SIZE] for aip in aips) == total_file_size
+    assert sum(aip[fields.FIELD_COUNT] for aip in aips) == total_file_count
+    assert sum(aip[fields.FIELD_SIZE] for aip in aips) == total_file_size

--- a/AIPscan/Data/tests/test_format_versions_count.py
+++ b/AIPscan/Data/tests/test_format_versions_count.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+
+from datetime import datetime
+import pytest
+
+from AIPscan.helpers import parse_datetime_bound
+from AIPscan.Data import fields, report_data
+from AIPscan.Data.tests import (
+    MOCK_STORAGE_SERVICE,
+    MOCK_STORAGE_SERVICE_ID,
+    MOCK_STORAGE_SERVICE_NAME,
+)
+from AIPscan.Data.tests.conftest import (
+    AIP_1_CREATION_DATE,
+    AIP_2_CREATION_DATE,
+    ORIGINAL_FILE_SIZE as JPEG_1_01_FILE_SIZE,
+    PRESERVATION_FILE_SIZE as JPEG_1_02_FILE_SIZE,
+)
+
+TOTAL_FILE_SIZE = JPEG_1_01_FILE_SIZE + JPEG_1_02_FILE_SIZE
+
+DATE_BEFORE_AIP_1 = "2019-01-01"
+DATE_AFTER_AIP_1 = "2020-01-02"
+DATE_BEFORE_AIP_2 = "2020-05-30"
+DATE_AFTER_AIP_2 = "2020-06-02"
+
+
+class MockFormatVersionsCountQueryResult:
+    """Fixture for mocking SQLAlchemy query results."""
+
+    def __init__(self, puid, file_format, format_version, file_count, total_size):
+        self.puid = puid
+        self.file_format = file_format
+        self.format_version = format_version
+        self.file_count = file_count
+        self.total_size = total_size
+
+
+MOCK_QUERY_RESULTS = [
+    MockFormatVersionsCountQueryResult(
+        puid="fmt/43",
+        file_format="JPEG",
+        format_version="1.01",
+        file_count=5,
+        total_size=12345678,
+    ),
+    MockFormatVersionsCountQueryResult(
+        puid="fmt/44",
+        file_format="JPEG",
+        format_version="1.02",
+        file_count=3,
+        total_size=1234567,
+    ),
+    MockFormatVersionsCountQueryResult(
+        puid="fmt/199",
+        file_format="MPEG-4 Media File",
+        format_version=None,
+        file_count=1,
+        total_size=12345,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "query_results, results_count",
+    [
+        # Empty result set, count is 0.
+        ([], 0),
+        # Test the return of complete result set, count is the length
+        # of all results.
+        (MOCK_QUERY_RESULTS, len(MOCK_QUERY_RESULTS)),
+        # Test the return of only the first two results, count is 2.
+        (MOCK_QUERY_RESULTS[:2], 2),
+    ],
+)
+def test_format_versions_count(app_instance, mocker, query_results, results_count):
+    """Test that results match high-level expectations."""
+    mock_query = mocker.patch("AIPscan.Data.report_data._format_versions_count_query")
+    mock_query.return_value = query_results
+
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
+
+    report = report_data.format_versions_count(
+        MOCK_STORAGE_SERVICE_ID, datetime.min, datetime.max
+    )
+    assert report[fields.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
+    assert len(report[fields.FIELD_FORMAT_VERSIONS]) == results_count
+
+
+@pytest.mark.parametrize(
+    "test_format_version", [mock_result for mock_result in MOCK_QUERY_RESULTS]
+)
+def test_format_versions_count_elements(app_instance, mocker, test_format_version):
+    """Test that structure of versions data matches expectations."""
+    mock_query = mocker.patch("AIPscan.Data.report_data._format_versions_count_query")
+    mock_query.return_value = [test_format_version]
+
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
+    mock_get_ss.return_value = MOCK_STORAGE_SERVICE
+
+    report = report_data.format_versions_count(
+        MOCK_STORAGE_SERVICE_ID, datetime.min, datetime.max
+    )
+    report_format_version = report[fields.FIELD_FORMAT_VERSIONS][0]
+
+    assert test_format_version.puid == report_format_version.get(fields.FIELD_PUID)
+    assert test_format_version.file_format == report_format_version.get(
+        fields.FIELD_FORMAT
+    )
+    assert test_format_version.format_version == report_format_version.get(
+        fields.FIELD_VERSION
+    )
+    assert test_format_version.file_count == report_format_version.get(
+        fields.FIELD_COUNT
+    )
+    assert test_format_version.total_size == report_format_version.get(
+        fields.FIELD_SIZE
+    )
+
+
+@pytest.mark.parametrize(
+    "start_date, end_date, version_count, total_file_count, total_file_size",
+    [
+        # Not specifying dates should return all files and versions.
+        (None, None, 3, 3, TOTAL_FILE_SIZE),
+        # Start date before first AIP was ingested hould return all
+        # files and versions.
+        (DATE_BEFORE_AIP_1, None, 3, 3, TOTAL_FILE_SIZE),
+        # Start date that's the same day our first AIP was ingested
+        # should return all files and versions.
+        (AIP_1_CREATION_DATE, None, 3, 3, TOTAL_FILE_SIZE),
+        # Start date after our first AIP was ingested should return
+        # only the second JPEG version and ISO disk image.
+        (DATE_AFTER_AIP_1, None, 2, 2, JPEG_1_02_FILE_SIZE),
+        # End date before second AIP was ingested should return only
+        # the first JPEG version.
+        (None, DATE_BEFORE_AIP_2, 1, 1, JPEG_1_01_FILE_SIZE),
+        # End date that's the same day our second AIP was ingested
+        # should return all files and versions.
+        (None, AIP_2_CREATION_DATE, 3, 3, TOTAL_FILE_SIZE),
+        # End date that's after our second AIP was ingested should
+        # return all files and versions.
+        (None, DATE_AFTER_AIP_2, 3, 3, TOTAL_FILE_SIZE),
+        # Start and end dates that define a range in which we haven't
+        # ingested any AIPs should return no files or versions.
+        ("2019-01-01", "2019-01-02", 0, 0, 0),
+        # Invalid values for start and end dates should be treated as
+        # None values and return both JPEG versions.
+        (True, "NOT A DATE", 3, 3, TOTAL_FILE_SIZE),
+    ],
+)
+def test_format_versions_count_contents(
+    app_with_populated_format_versions,
+    start_date,
+    end_date,
+    version_count,
+    total_file_count,
+    total_file_size,
+):
+    """Test that content of response matches expectations.
+
+    This integration test uses a pre-populated fixture to verify that
+    the database access layer of our endpoint returns what we expect.
+    """
+    results = report_data.format_versions_count(
+        storage_service_id=1,
+        start_date=parse_datetime_bound(start_date),
+        end_date=parse_datetime_bound(end_date, upper=True),
+    )
+    versions = results[fields.FIELD_FORMAT_VERSIONS]
+    assert len(versions) == version_count
+    assert (
+        sum(version.get(fields.FIELD_COUNT, 0) for version in versions)
+        == total_file_count
+    )
+    assert (
+        sum(version.get(fields.FIELD_SIZE, 0) for version in versions)
+        == total_file_size
+    )

--- a/AIPscan/Data/tests/test_largest_files.py
+++ b/AIPscan/Data/tests/test_largest_files.py
@@ -3,7 +3,7 @@ import datetime
 import pytest
 import uuid
 
-from AIPscan.Data import data
+from AIPscan.Data import fields, report_data
 from AIPscan.Data.tests import (
     MOCK_AIP,
     MOCK_AIP_NAME,
@@ -64,18 +64,18 @@ TEST_FILES = [
 def test_largest_files(app_instance, mocker, file_data, file_count):
     """Test that return value conforms to expected structure.
     """
-    mock_query = mocker.patch("AIPscan.Data.data._largest_files_query")
+    mock_query = mocker.patch("AIPscan.Data.report_data._largest_files_query")
     mock_query.return_value = file_data
 
-    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
     mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
     mock_get_aip = mocker.patch("sqlalchemy.orm.query.Query.get")
     mock_get_aip.return_value = MOCK_AIP
 
-    report = data.largest_files(MOCK_STORAGE_SERVICE_ID)
-    report_files = report[data.FIELD_FILES]
-    assert report[data.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
+    report = report_data.largest_files(MOCK_STORAGE_SERVICE_ID)
+    report_files = report[fields.FIELD_FILES]
+    assert report[fields.FIELD_STORAGE_NAME] == MOCK_STORAGE_SERVICE_NAME
     assert len(report_files) == file_count
 
 
@@ -92,33 +92,33 @@ def test_largest_files_elements(
 ):
     """Test that returned file data matches expected values.
     """
-    mock_query = mocker.patch("AIPscan.Data.data._largest_files_query")
+    mock_query = mocker.patch("AIPscan.Data.report_data._largest_files_query")
     mock_query.return_value = [test_file]
 
-    mock_get_ss = mocker.patch("AIPscan.Data.data._get_storage_service")
+    mock_get_ss = mocker.patch("AIPscan.Data.report_data._get_storage_service")
     mock_get_ss.return_value = MOCK_STORAGE_SERVICE
 
     mock_get_aip = mocker.patch("sqlalchemy.orm.query.Query.get")
     mock_get_aip.return_value = MOCK_AIP
 
-    report = data.largest_files(MOCK_STORAGE_SERVICE_ID)
-    report_file = report[data.FIELD_FILES][0]
+    report = report_data.largest_files(MOCK_STORAGE_SERVICE_ID)
+    report_file = report[fields.FIELD_FILES][0]
 
     # Required elements
-    assert test_file.name == report_file.get(data.FIELD_NAME)
-    assert test_file.file_format == report_file.get(data.FIELD_FORMAT)
+    assert test_file.name == report_file.get(fields.FIELD_NAME)
+    assert test_file.file_format == report_file.get(fields.FIELD_FORMAT)
 
     # Optional elements
     if has_format_version:
-        assert test_file.format_version == report_file.get(data.FIELD_VERSION)
+        assert test_file.format_version == report_file.get(fields.FIELD_VERSION)
     else:
-        assert report_file.get(data.FIELD_VERSION) is None
+        assert report_file.get(fields.FIELD_VERSION) is None
 
     if has_puid:
-        assert test_file.puid == report_file.get(data.FIELD_PUID)
+        assert test_file.puid == report_file.get(fields.FIELD_PUID)
     else:
-        assert report_file.get(data.FIELD_PUID) is None
+        assert report_file.get(fields.FIELD_PUID) is None
 
     # AIP information
-    assert report_file.get(data.FIELD_AIP_NAME) == MOCK_AIP_NAME
-    assert report_file.get(data.FIELD_AIP_UUID) == MOCK_AIP_UUID
+    assert report_file.get(fields.FIELD_AIP_NAME) == MOCK_AIP_NAME
+    assert report_file.get(fields.FIELD_AIP_UUID) == MOCK_AIP_UUID

--- a/AIPscan/Reporter/helpers.py
+++ b/AIPscan/Reporter/helpers.py
@@ -4,7 +4,7 @@
 """
 from natsort import natsorted
 
-from AIPscan.Data import data
+from AIPscan.Data import fields
 
 
 def sort_puids(puids):
@@ -27,28 +27,28 @@ def translate_headers(headers):
     more user friendly and translatable.
     """
     field_lookup = {
-        data.FIELD_AIP_NAME: "AIP Name",
-        data.FIELD_AIPS: "AIPs",
-        data.FIELD_AIP_SIZE: "AIP Size",
-        data.FIELD_ALL_AIPS: "All AIPs",
-        data.FIELD_COUNT: "Count",
-        data.FIELD_CREATED_DATE: "Created Date",
-        data.FIELD_DERIVATIVE_COUNT: "Derivative Count",
-        data.FIELD_DERIVATIVE_FORMAT: "Derivative Format",
-        data.FIELD_DERIVATIVE_UUID: "Derivative UUID",
-        data.FIELD_FILE_COUNT: "File Count",
-        data.FIELD_FILE_TYPE: "Type",
-        data.FIELD_FILENAME: "Filename",
-        data.FIELD_FORMAT: "Format",
-        data.FIELD_FORMATS: "Formats",
-        data.FIELD_NAME: "Name",
-        data.FIELD_ORIGINAL_UUID: "Original UUID",
-        data.FIELD_ORIGINAL_FORMAT: "Original Format",
-        data.FIELD_PUID: "PUID",
-        data.FIELD_RELATED_PAIRING: "Related Pairing",
-        data.FIELD_SIZE: "Size",
-        data.FIELD_STORAGE_NAME: "Storage Service Name",
-        data.FIELD_TRANSFER_NAME: "Transfer Name",
-        data.FIELD_VERSION: "Version",
+        fields.FIELD_AIP_NAME: "AIP Name",
+        fields.FIELD_AIPS: "AIPs",
+        fields.FIELD_AIP_SIZE: "AIP Size",
+        fields.FIELD_ALL_AIPS: "All AIPs",
+        fields.FIELD_COUNT: "Count",
+        fields.FIELD_CREATED_DATE: "Created Date",
+        fields.FIELD_DERIVATIVE_COUNT: "Derivative Count",
+        fields.FIELD_DERIVATIVE_FORMAT: "Derivative Format",
+        fields.FIELD_DERIVATIVE_UUID: "Derivative UUID",
+        fields.FIELD_FILE_COUNT: "File Count",
+        fields.FIELD_FILE_TYPE: "Type",
+        fields.FIELD_FILENAME: "Filename",
+        fields.FIELD_FORMAT: "Format",
+        fields.FIELD_FORMATS: "Formats",
+        fields.FIELD_NAME: "Name",
+        fields.FIELD_ORIGINAL_UUID: "Original UUID",
+        fields.FIELD_ORIGINAL_FORMAT: "Original Format",
+        fields.FIELD_PUID: "PUID",
+        fields.FIELD_RELATED_PAIRING: "Related Pairing",
+        fields.FIELD_SIZE: "Size",
+        fields.FIELD_STORAGE_NAME: "Storage Service Name",
+        fields.FIELD_TRANSFER_NAME: "Transfer Name",
+        fields.FIELD_VERSION: "Version",
     }
     return [field_lookup.get(header, header) for header in headers]

--- a/AIPscan/Reporter/report_aip_contents.py
+++ b/AIPscan/Reporter/report_aip_contents.py
@@ -2,7 +2,7 @@
 
 from flask import render_template, request
 
-from AIPscan.Data import data
+from AIPscan.Data import data, fields
 from AIPscan.helpers import get_human_readable_file_size
 from AIPscan.Reporter import reporter, translate_headers, request_params
 
@@ -15,31 +15,31 @@ def aip_contents():
     FIELD_UUID = "UUID"
     headers = [
         FIELD_UUID,
-        data.FIELD_AIP_NAME,
-        data.FIELD_CREATED_DATE,
-        data.FIELD_AIP_SIZE,
+        fields.FIELD_AIP_NAME,
+        fields.FIELD_CREATED_DATE,
+        fields.FIELD_AIP_SIZE,
     ]
-    format_lookup = aip_data[data.FIELD_FORMATS]
-    format_headers = list(aip_data[data.FIELD_FORMATS].keys())
-    storage_service_name = aip_data[data.FIELD_STORAGE_NAME]
-    aip_data.pop(data.FIELD_FORMATS, None)
-    aip_data.pop(data.FIELD_STORAGE_NAME, None)
+    format_lookup = aip_data[fields.FIELD_FORMATS]
+    format_headers = list(aip_data[fields.FIELD_FORMATS].keys())
+    storage_service_name = aip_data[fields.FIELD_STORAGE_NAME]
+    aip_data.pop(fields.FIELD_FORMATS, None)
+    aip_data.pop(fields.FIELD_STORAGE_NAME, None)
     rows = []
     for k, v in aip_data.items():
         row = []
         for header in headers:
             if header == FIELD_UUID:
                 row.append(k)
-            elif header == data.FIELD_AIP_SIZE:
+            elif header == fields.FIELD_AIP_SIZE:
                 row.append(get_human_readable_file_size(v.get(header)))
-            elif header != data.FIELD_FORMATS:
+            elif header != fields.FIELD_FORMATS:
                 row.append(v.get(header))
-        formats = v.get(data.FIELD_FORMATS)
+        formats = v.get(fields.FIELD_FORMATS)
         for format_header in format_headers:
             format_ = formats.get(format_header)
             count = 0
             if format_:
-                count = format_.get(data.FIELD_COUNT, 0)
+                count = format_.get(fields.FIELD_COUNT, 0)
             row.append(count)
         rows.append(row)
     headers = headers + format_headers

--- a/AIPscan/Reporter/report_aips_by_format.py
+++ b/AIPscan/Reporter/report_aips_by_format.py
@@ -3,7 +3,7 @@
 from flask import render_template, request
 
 from AIPscan.helpers import parse_bool
-from AIPscan.Data import data
+from AIPscan.Data import fields, report_data
 from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
@@ -15,18 +15,23 @@ def aips_by_format():
     original_files = parse_bool(
         request.args.get(request_params["original_files"], True)
     )
-    aip_data = data.aips_by_file_format(
+    aip_data = report_data.aips_by_file_format(
         storage_service_id=storage_service_id,
         file_format=file_format,
         original_files=original_files,
     )
-    headers = [data.FIELD_AIP_NAME, data.FIELD_UUID, data.FIELD_COUNT, data.FIELD_SIZE]
+    headers = [
+        fields.FIELD_AIP_NAME,
+        fields.FIELD_UUID,
+        fields.FIELD_COUNT,
+        fields.FIELD_SIZE,
+    ]
     return render_template(
         "report_aips_by_format.html",
         storage_service_id=storage_service_id,
-        storage_service_name=aip_data.get(data.FIELD_STORAGE_NAME),
+        storage_service_name=aip_data.get(fields.FIELD_STORAGE_NAME),
         file_format=file_format,
         original_files=original_files,
         columns=translate_headers(headers),
-        aips=aip_data.get(data.FIELD_AIPS),
+        aips=aip_data.get(fields.FIELD_AIPS),
     )

--- a/AIPscan/Reporter/report_aips_by_puid.py
+++ b/AIPscan/Reporter/report_aips_by_puid.py
@@ -4,7 +4,7 @@ from flask import render_template, request
 
 from AIPscan.helpers import parse_bool
 from AIPscan.models import File
-from AIPscan.Data import data
+from AIPscan.Data import fields, report_data
 from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
@@ -39,17 +39,22 @@ def aips_by_puid():
     original_files = parse_bool(
         request.args.get(request_params["original_files"], True)
     )
-    aip_data = data.aips_by_puid(
+    aip_data = report_data.aips_by_puid(
         storage_service_id=storage_service_id, puid=puid, original_files=original_files
     )
-    headers = [data.FIELD_AIP_NAME, data.FIELD_UUID, data.FIELD_COUNT, data.FIELD_SIZE]
+    headers = [
+        fields.FIELD_AIP_NAME,
+        fields.FIELD_UUID,
+        fields.FIELD_COUNT,
+        fields.FIELD_SIZE,
+    ]
     return render_template(
         "report_aips_by_puid.html",
         storage_service_id=storage_service_id,
-        storage_service_name=aip_data.get(data.FIELD_STORAGE_NAME),
+        storage_service_name=aip_data.get(fields.FIELD_STORAGE_NAME),
         puid=puid,
         file_format=get_format_string_from_puid(puid),
         original_files=original_files,
         columns=translate_headers(headers),
-        aips=aip_data.get(data.FIELD_AIPS),
+        aips=aip_data.get(fields.FIELD_AIPS),
     )

--- a/AIPscan/Reporter/report_format_versions_count.py
+++ b/AIPscan/Reporter/report_format_versions_count.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+from flask import render_template, request
+
+from AIPscan.helpers import parse_datetime_bound
+from AIPscan.Data import fields, report_data
+from AIPscan.Reporter import reporter, translate_headers, request_params
+
+
+@reporter.route("/report_format_versions_count/", methods=["GET"])
+def report_format_versions_count():
+    """Return overview of format versions in Storage Service."""
+    storage_service_id = request.args.get(request_params["storage_service_id"])
+    start_date = parse_datetime_bound(request.args.get(request_params["start_date"]))
+    end_date = parse_datetime_bound(
+        request.args.get(request_params["end_date"]), upper=True
+    )
+
+    version_data = report_data.format_versions_count(
+        storage_service_id=storage_service_id, start_date=start_date, end_date=end_date
+    )
+    versions = version_data.get(fields.FIELD_FORMAT_VERSIONS)
+
+    headers = [
+        fields.FIELD_PUID,
+        fields.FIELD_FORMAT,
+        fields.FIELD_VERSION,
+        fields.FIELD_COUNT,
+        fields.FIELD_SIZE,
+    ]
+
+    # Remove day added to end date for purposes of comparison by
+    # parse_datetime_bound before passing to template.
+    display_end_date = end_date - timedelta(days=1)
+
+    return render_template(
+        "report_format_versions_count.html",
+        storage_service_id=storage_service_id,
+        storage_service_name=version_data.get(fields.FIELD_STORAGE_NAME),
+        columns=translate_headers(headers),
+        versions=versions,
+        total_file_count=sum(
+            version.get(fields.FIELD_COUNT, 0) for version in versions
+        ),
+        total_size=sum(version.get(fields.FIELD_SIZE, 0) for version in versions),
+        puid_count=len(versions),
+        start_date=start_date,
+        end_date=display_end_date,
+    )

--- a/AIPscan/Reporter/report_formats_count.py
+++ b/AIPscan/Reporter/report_formats_count.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 
 from flask import render_template, request
 
-from AIPscan.models import AIP, Event, File, FileType, StorageService
+from AIPscan.models import AIP, File, FileType, StorageService
 from AIPscan.helpers import get_human_readable_file_size
 from AIPscan.Reporter import reporter, request_params
 
@@ -41,16 +41,9 @@ def report_formats_count():
             aip_id=aip.id, file_type=FileType.original
         )
         for original in original_files:
-            # Note that original files in packages do not have a PREMIS ingestion
-            # event. Therefore "message digest calculation" is used to get the
-            # ingest date for all originals. This event typically happens within
-            # the same second or seconds of the ingestion event and is done for all files.
-            ingest_event = Event.query.filter_by(
-                file_id=original.id, type="message digest calculation"
-            ).first()
-            if ingest_event.date < day_before:
+            if aip.create_date < day_before:
                 continue
-            elif ingest_event.date > day_after:
+            elif aip.create_date > day_after:
                 continue
             else:
                 file_format = original.file_format
@@ -117,16 +110,9 @@ def chart_formats_count():
             aip_id=aip.id, file_type=FileType.original
         )
         for original in original_files:
-            # Note that original files in packages do not have a PREMIS ingestion
-            # event. Therefore "message digest calculation" is used to get the
-            # ingest date for all originals. This event typically happens within
-            # the same second or seconds of the ingestion event and is done for all files.
-            ingest_event = Event.query.filter_by(
-                file_id=original.id, type="message digest calculation"
-            ).first()
-            if ingest_event.date < day_before:
+            if aip.create_date < day_before:
                 continue
-            elif ingest_event.date > day_after:
+            elif aip.create_date > day_after:
                 continue
             else:
                 format_labels.append(original.file_format)
@@ -175,16 +161,9 @@ def plot_formats_count():
             aip_id=aip.id, file_type=FileType.original
         )
         for original in original_files:
-            # Note that original files in packages do not have a PREMIS ingestion
-            # event. Therefore "message digest calculation" is used to get the
-            # ingest date for all originals. This event typically happens within
-            # the same second or seconds of the ingestion event and is done for all files.
-            ingest_event = Event.query.filter_by(
-                file_id=original.id, type="message digest calculation"
-            ).first()
-            if ingest_event.date < day_before:
+            if aip.create_date < day_before:
                 continue
-            elif ingest_event.date > day_after:
+            elif aip.create_date > day_after:
                 continue
             else:
                 file_format = original.file_format

--- a/AIPscan/Reporter/report_ingest_log.py
+++ b/AIPscan/Reporter/report_ingest_log.py
@@ -8,7 +8,7 @@ import pandas as pd
 import plotly.express as px
 
 
-from AIPscan.Data import data
+from AIPscan.Data import report_data
 from AIPscan.helpers import _simplify_datetime
 from AIPscan.Reporter import reporter, request_params
 
@@ -54,7 +54,7 @@ def ingest_log_tabular():
     """Return the information needed to present an ingest gantt chart."""
     TABULAR_TEMPLATE = "report_ingest_log_tabular.html"
     storage_service_id = request.args.get(request_params[STORAGE_SERVICE_ID])
-    ingests = data.agents_transfers(storage_service_id)
+    ingests = report_data.agents_transfers(storage_service_id)
     ingests = get_table_data(ingests)
     return render_template(
         TABULAR_TEMPLATE,
@@ -96,7 +96,7 @@ def ingest_log():
     """Return the information needed to present an ingest gantt chart."""
     GANTT_TEMPLATE = "report_ingest_log_gantt.html"
     storage_service_id = request.args.get(request_params[STORAGE_SERVICE_ID])
-    ingests = data.agents_transfers(storage_service_id)
+    ingests = report_data.agents_transfers(storage_service_id)
     ingests = get_figure_html(ingests)
     return render_template(
         GANTT_TEMPLATE,

--- a/AIPscan/Reporter/report_largest_files.py
+++ b/AIPscan/Reporter/report_largest_files.py
@@ -2,7 +2,7 @@
 
 from flask import render_template, request
 
-from AIPscan.Data import data
+from AIPscan.Data import fields, report_data
 from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
@@ -16,24 +16,24 @@ def largest_files():
         limit = int(request.args.get(request_params["limit"], 20))
     except ValueError:
         pass
-    file_data = data.largest_files(
+    file_data = report_data.largest_files(
         storage_service_id=storage_service_id, file_type=file_type, limit=limit
     )
-    storage_service_name = file_data[data.FIELD_STORAGE_NAME]
+    storage_service_name = file_data[fields.FIELD_STORAGE_NAME]
     headers = [
-        data.FIELD_FILENAME,
-        data.FIELD_SIZE,
-        data.FIELD_FORMAT,
-        data.FIELD_PUID,
-        data.FIELD_FILE_TYPE,
-        data.FIELD_AIP_NAME,
+        fields.FIELD_FILENAME,
+        fields.FIELD_SIZE,
+        fields.FIELD_FORMAT,
+        fields.FIELD_PUID,
+        fields.FIELD_FILE_TYPE,
+        fields.FIELD_AIP_NAME,
     ]
     return render_template(
         "report_largest_files.html",
         storage_service_id=storage_service_id,
         storage_service_name=storage_service_name,
         columns=translate_headers(headers),
-        files=file_data[data.FIELD_FILES],
+        files=file_data[fields.FIELD_FILES],
         file_type=file_type,
         limit=limit,
     )

--- a/AIPscan/Reporter/report_originals_with_derivatives.py
+++ b/AIPscan/Reporter/report_originals_with_derivatives.py
@@ -6,7 +6,7 @@ the different file formats associated with both.
 
 from flask import render_template, request
 
-from AIPscan.Data import data
+from AIPscan.Data import data, fields
 from AIPscan.Reporter import reporter, translate_headers, request_params
 
 
@@ -18,27 +18,27 @@ def original_derivatives():
     aips_with_preservation_files = []
     storage_service_id = request.args.get(request_params["storage_service_id"])
     derivative_data = data.derivative_overview(storage_service_id=storage_service_id)
-    storage_service_name = derivative_data[data.FIELD_STORAGE_NAME]
+    storage_service_name = derivative_data[fields.FIELD_STORAGE_NAME]
 
-    for aip in derivative_data[data.FIELD_ALL_AIPS]:
+    for aip in derivative_data[fields.FIELD_ALL_AIPS]:
         aip_info = {}
-        aip_info[data.FIELD_TRANSFER_NAME] = aip[data.FIELD_TRANSFER_NAME]
-        aip_info[data.FIELD_UUID] = aip[data.FIELD_UUID]
-        aip_info[data.FIELD_DERIVATIVE_COUNT] = aip[data.FIELD_DERIVATIVE_COUNT]
+        aip_info[fields.FIELD_TRANSFER_NAME] = aip[fields.FIELD_TRANSFER_NAME]
+        aip_info[fields.FIELD_UUID] = aip[fields.FIELD_UUID]
+        aip_info[fields.FIELD_DERIVATIVE_COUNT] = aip[fields.FIELD_DERIVATIVE_COUNT]
         aip_info["table_data"] = []
-        for pairing in aip[data.FIELD_RELATED_PAIRING]:
+        for pairing in aip[fields.FIELD_RELATED_PAIRING]:
             row = []
-            row.append(pairing[data.FIELD_ORIGINAL_UUID])
-            row.append(pairing[data.FIELD_ORIGINAL_FORMAT])
-            row.append(pairing[data.FIELD_DERIVATIVE_UUID])
-            row.append(pairing[data.FIELD_DERIVATIVE_FORMAT])
+            row.append(pairing[fields.FIELD_ORIGINAL_UUID])
+            row.append(pairing[fields.FIELD_ORIGINAL_FORMAT])
+            row.append(pairing[fields.FIELD_DERIVATIVE_UUID])
+            row.append(pairing[fields.FIELD_DERIVATIVE_FORMAT])
             aip_info["table_data"].append(row)
         aips_with_preservation_files.append(aip_info)
     headers = [
-        data.FIELD_ORIGINAL_UUID,
-        data.FIELD_ORIGINAL_FORMAT,
-        data.FIELD_DERIVATIVE_UUID,
-        data.FIELD_DERIVATIVE_FORMAT,
+        fields.FIELD_ORIGINAL_UUID,
+        fields.FIELD_ORIGINAL_FORMAT,
+        fields.FIELD_DERIVATIVE_UUID,
+        fields.FIELD_DERIVATIVE_FORMAT,
     ]
     return render_template(
         "report_originals_derivatives.html",

--- a/AIPscan/Reporter/templates/report_format_versions_count.html
+++ b/AIPscan/Reporter/templates/report_format_versions_count.html
@@ -1,0 +1,51 @@
+{% extends "report_base.html" %}
+
+{% block content %}
+
+  <div class="alert alert-secondary">
+    <a class="noprint" onClick="window.print();return false">
+      <button type="button" class="btn btn-info" style="float:right;">Print</button>
+    </a>
+    <strong>Report:</strong> File format version count
+    <br>
+    <strong>Storage Service:</strong> {{ storage_service_name }}
+    <br>
+    {% if start_date and end_date %}
+      {{ total_file_count }} original files ingested between {{ start_date.strftime('%Y-%m-%d') }} and {{ end_date.strftime('%Y-%m-%d') }}
+    {% elif start_date %}
+      {{ total_file_count }} original files ingested on and since {{ start_date.strftime('%Y-%m-%d') }}
+    {% elif end_date %}
+      {{ total_file_count }} original files ingested on and before {{ end_date.strftime('%Y-%m-%d') }}
+    {% else %}
+      {{ total_file_count }} original files
+    {% endif %}
+    <br>
+    {{ puid_count }} different format versions totalling {{ total_size | filesizeformat }}
+  </div>
+
+  {% if versions %}
+    <table id="formatversioncounts" class="table table-striped table-bordered">
+      <thead>
+        <tr>
+          {% for column in columns %}
+          <th><strong>{{ column }}</strong></th>
+          {% endfor %}
+        </tr>
+      </thead>
+      <tbody>
+      {% for version in versions %}
+        <tr>
+          <td>{{ version["PUID"] }}</td>
+          <td>{{ version["Format"] }}</td>
+          <td>{{ version["Version"] }}</td>
+          <td>{{ version["Count"] }}</td>
+          <td>{{ version["Size"] | filesizeformat }}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  {% else %}
+    <p class="h4" style="margin-top:20px;">No file format versions to display.</p>
+  {% endif %}
+
+{% endblock %}

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -2,8 +2,6 @@
 
 {% block content %}
 
-<div class="container-alert"></div>
-
 <div class="alert alert-header"><strong>Reports</strong></div>
 
 {% if storage_services %}
@@ -37,8 +35,7 @@
         <tr>
             <td>File format count</td>
             <td></td>
-            <td><input id="startdate1" type="text" value="{{ start_date }}">
-            </td>
+            <td><input type="text" id="startdate1" value="{{ start_date }}"></td>
             <td><input type="text" id="enddate1" value="{{ end_date }}"></td>
             <td><a href=""><button type="button" id="report1a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a><a href=""><button type="button" id="report1b" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Pie Chart</button></a><a href=""><button type="button" id="report1c" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Scatter Plot</button></a></td>
         </tr>
@@ -54,8 +51,8 @@
         <tr>
             <td>Format version count</td>
             <td></td>
-            <td></td>
-            <td></td>
+            <td><input type="text" id="fmt_version_count_start_date" value="{{ start_date }}"></td>
+            <td><input type="text" id="fmt_version_count_end_date" value="{{ end_date }}"></td>
             <td><a href="#"><button type="button" id="report3a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
         </tr>
 
@@ -183,26 +180,6 @@
 
 <!-- TODO: Let's get this into a separate JS and import it... -->
 <script>
-
-    const WARNINGS = {
-      ALERT_SECONDARY: "secondary",
-      ALERT_INFO: "info",
-    };
-
-    // TODO: This should be a generic function across the app, so let's get
-    // this into it's own import too.
-    //
-    // TODO: Are there more idiomatic approaches? 🤷
-    bootstrap_alert = function(message, alertType) {
-      $("body > div > div.container-alert").html(
-        '<div class="alert alert-' +
-        alertType +
-        '"><a class="close" data-dismiss="alert">×</a><span>' +
-        message +
-        "</span></div>"
-      )
-    }
-
     $(document).ready(function() {
         // Refresh page with storage_service_id parameter when user selects a
         // Storage Service from the dropdown list. This enables us to provide
@@ -216,13 +193,17 @@
             storageServiceId;
           window.location.href = url;
         });
+
+        const DATE_ALERT_START = 'The start date must be before the end date';
+        const DATE_ALERT_END = 'The end date must be after the start date';
+
         $("#startdate1").datepicker({
             dateFormat: 'yy-mm-dd',
             onSelect: function(date) {
                 var enddate = $('#enddate1').val();
                 if (enddate != "") {
                     if (enddate < date) {
-                        alert("The start date must be before the end date");
+                        alert(DATE_ALERT_START);
                     }
                 }
             }
@@ -233,7 +214,29 @@
                 var startdate = $('#startdate1').val();
                 if (startdate != "") {
                     if (startdate > date) {
-                        alert("The start date must be before the end date");
+                        alert(DATE_ALERT_END);
+                    }
+                }
+            }
+        });
+        $("#fmt_version_count_start_date").datepicker({
+            dateFormat: 'yy-mm-dd',
+            onSelect: function(date) {
+                var enddate = $('#fmt_version_count_end_date').val();
+                if (enddate != "") {
+                    if (enddate < date) {
+                        alert(DATE_ALERT_START);
+                    }
+                }
+            }
+        });
+        $("#fmt_version_count_end_date").datepicker({
+            dateFormat: 'yy-mm-dd',
+            onSelect: function(date) {
+                var startdate = $('#fmt_version_count_start_date').val();
+                if (startdate != "") {
+                    if (startdate > date) {
+                        alert(DATE_ALERT_END);
                     }
                 }
             }
@@ -242,7 +245,7 @@
             var startdate = $('#startdate1').val();
             var enddate = $('#enddate1').val();
             if (enddate < startdate) {
-                alert("The start date must be before the end date");
+                alert(DATE_ALERT_START);
             } else {
                 var storageServiceId = $('#ss').val();
                 var url = window.location.origin +
@@ -259,7 +262,7 @@
             var startdate = $('#startdate1').val();
             var enddate = $('#enddate1').val();
             if (enddate < startdate) {
-                alert("The start date must be before the end date");
+                alert(DATE_ALERT_START);
             } else {
                 var storageServiceId = $('#ss').val();
                 var url = window.location.origin +
@@ -276,7 +279,7 @@
             var startdate = $('#startdate1').val();
             var enddate = $('#enddate1').val();
             if (enddate < startdate) {
-                alert("The start date must be before the end date");
+                alert(DATE_ALERT_START);
             } else {
                 var storageServiceId = $('#ss').val();
                 var url = window.location.origin +
@@ -290,7 +293,6 @@
             }
         });
         $("#report2a").on("click", function() {
-            bootstrap_alert('This is a demo of report two!', WARNINGS.ALERT_SECONDARY);
             const URL_AIP_CONTENTS = "/reporter/aip_contents/"
             var storageServiceID = $('#ss').val();
             var url = (
@@ -302,10 +304,27 @@
             window.open(url);
         });
         $("#report3a").on("click", function() {
-            bootstrap_alert('Coming soon...', WARNINGS.ALERT_INFO);
+            var startdate = $('#fmt_version_count_start_date').val();
+            var enddate = $('#fmt_version_count_end_date').val();
+            if (enddate < startdate) {
+                alert(DATE_ALERT_START);
+            } else {
+                const URL_FORMAT_VERSION_COUNT = "/reporter/report_format_versions_count/";
+                var storageServiceID = $('#ss').val();
+                var url = (
+                  window.location.origin +
+                  URL_FORMAT_VERSION_COUNT +
+                  '?amss_id=' +
+                  storageServiceID +
+                  '&start_date=' +
+                  startdate +
+                  '&end_date=' +
+                  enddate
+                );
+                window.open(url);
+            }
         });
         $("#report4a").on("click", function() {
-            bootstrap_alert('This is a demo of report three!', WARNINGS.ALERT_SECONDARY);
             const URL_AIP_CONTENTS = "/reporter/original_derivatives/";
             var storageServiceID = $('#ss').val();
             var url = (

--- a/AIPscan/Reporter/views.py
+++ b/AIPscan/Reporter/views.py
@@ -19,6 +19,7 @@ from AIPscan.Reporter import (  # noqa: F401
     report_aips_by_format,
     report_aips_by_puid,
     report_formats_count,
+    report_format_versions_count,
     report_originals_with_derivatives,
     report_largest_files,
     report_ingest_log,

--- a/AIPscan/helpers.py
+++ b/AIPscan/helpers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-
+from datetime import datetime, timedelta
 from distutils.util import strtobool
 
 
@@ -10,6 +9,40 @@ def parse_bool(val, default=True):
         return bool(strtobool(val))
     except (ValueError, AttributeError):
         return default
+
+
+def parse_datetime_bound(date_string, upper=False):
+    """Parse date parameter string into datetime object.
+
+    Date parameters come in from the UI or API as date strings. This
+    helper converts these date strings to datetime objects for use in
+    filtering by date range in Data endpoints.
+
+    Date filtering in SQLAlchemy queries in the Data endpoint will be
+    inclusive when the following rules are followed:
+    - Use >= for start_date comparison
+    - Use < for end_date comparison
+
+    None or invalid start and end date values are set to datetime.min
+    and datetime.max respectively.
+
+    :param date_string: Date string. Valid format is YYYY-MM-DD (str).
+    :param upper: Flag indicating if date string being parsed is
+        the upper bound, with default of False (bool).
+
+    :returns: datetime.datetime object
+    """
+    default_datetime = datetime.min
+    if upper:
+        default_datetime = datetime.max
+
+    try:
+        parsed_datetime = datetime.strptime(date_string, "%Y-%m-%d")
+        if upper:
+            parsed_datetime = parsed_datetime + timedelta(days=1)
+        return parsed_datetime
+    except (TypeError, ValueError):
+        return default_datetime
 
 
 def get_human_readable_file_size(size, precision=2):


### PR DESCRIPTION
Connected to #93 

This PR implements the "Format versions count" report in the UI and API, with support for limiting results by start and end date. This commit also removes the Bootstrap alerts from the report selection template, as there is no longer the need for any "Coming soon"-type messages, and users should be able to tell that their reports are loading in a new tab without these alerts.

**NB:** With reference to this conversation in https://github.com/artefactual-labs/AIPscan/pull/65#discussion_r534446391, I suspect that some changes will need to be made around implementing the `start_date` and `end_date` parameters before merging. This might mean changing this report to use files' ingestion `Event` date or it might mean modifying the "File format count" report to use `AIP.create_date`, as I've done here. My rationale for using `AIP.create_date` is that that date is likely the most visible date for Archivematica users, since it is displayed in both the Archival Storage tab and the Storage Service's Package tab. But honestly, I'm not really sure which is the better approach and would like some input, as I'd like to set a standard practice and use that moving forward wherever possible.

In many cases, file ingestion dates and AIP creation dates will be the same, or at least similar. But in some cases, as in the case of files that are stored in a transfer backlog for weeks or months prior to becoming part of a SIP (and, eventually, an AIP), they may end up being quite different.

So when we say "start date" and "end date" in relation to something like this report, or the "File format count" report, do we mean when the file was first ingested into an Archivematica instance, or when it became part of an AIP? Might that answer change for other reports? How might we better communicate what these dates mean to users? (I've tried in the API documentation with some success, I think, but am more at a loss for what to do in the GUI)

