### PR TITLE
Revert incorrect handling of FAILURE status (fetch job statuses)

### DIFF
--- a/AIPscan/static/js/tasks.js
+++ b/AIPscan/static/js/tasks.js
@@ -17,29 +17,20 @@ function new_fetch_job(storageServiceId){
 }
 
 function package_list_task_status(taskId, showcount, fetchJobId){
-  const inspect_logs = ": Please inspect the celery logs"
   const status_pending = 'PENDING'
   const status_progress = 'IN PROGRESS'
-  const status_failure = "FAILURE"
   $.ajax({
     type: 'GET',
     url: '/aggregator/package_list_task_status/' + taskId,
     datatype: "json",
     success: function(data) {
-      state = data['state']
-      if (state != status_pending && state != status_progress && state != status_failure) {
+      let state = data['state'];
+      if (state != status_pending && state != status_progress) {
         $('#console').append('<div class="log">' + state +'</div>')
         $('#console').append('<div class="log">Downloading AIP METS files</div>')
         get_mets_task_status(data["coordinatorId"], 0, fetchJobId);
       }
-      if (state == status_failure) {
-        err = "".concat('<div class="log">', state, inspect_logs ,'</div>')
-        $('#console').append(err)
-        return
-      }
       else {
-        output = "".concat('<div class="log">', state, ': Downloading AIP METS files</div>')
-        $('#console').append(output)
         if (showcount == false) {
           if ('message' in data){
             $('#console').append('<div class="log">' + data["message"] +'</div>')


### PR DESCRIPTION
FAILURE handling was added incorrectly to package_list_task_status.
This commit reverts those changes to make the console output work
as it did previously. This also quietens down the completed tasks
alerts as well.

Resolves #72 
Resolves #73 

@peterVG first, apologies for my speaking out of term the other day. I had diagnosed this wrong. Looking again tonight I have discovered a mis-reading of the original JavaScript functions you had created when I changed them here: https://github.com/artefactual-labs/AIPscan/commit/e59056e9ffa01213fa6517da898946493e13c5e3#diff-606a3136c88e560ab867ae3abac4c67013a7a577f7b69878f20c7939fa99e179. I have not tried to add FAILURE handling in again as this might be something you do differently with your current work, and so this just reverts the change back to a working JavaScript. If you have an opportunity to test and review we'll get this merged and it should be one less annoyance :slightly_smiling_face: 

_Recorded tonight:_

![Peek 2020-12-02 23-07](https://user-images.githubusercontent.com/1880412/100962899-4a1c5480-34f3-11eb-8ac0-62648c9f05b4.gif)
