### PR TITLE
Generate and upload coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+
+omit =
+    **/static/*
+    **/templates/*
+    **/tests/*
+
+source = AIPscan
+
+branch = True

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,16 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
         run: |
-          tox
+          tox -- --cov AIPscan --cov-config .coveragerc --cov-report xml:coverage.xml
+      - name: "Upload coverage report"
+        if: github.repository == 'artefactual-labs/AIPscan'
+        uses: "codecov/codecov-action@v1"
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
+          verbose: true
+          name: ${{ matrix.toxenv }}
+          flags: ${{ matrix.toxenv }}
   lint:
     name: "Lint"
     runs-on: "ubuntu-18.04"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![GitHub CI](https://github.com/artefactual-labs/AIPscan/actions/workflows/test.yml/badge.svg)](https://github.com/artefactual-labs/AIPscan/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/artefactual-labs/AIPscan/branch/main/graph/badge.svg?token=2RRFAM8P89)](https://codecov.io/gh/artefactual-labs/AIPscan)
+
 # AIPscan
 
 Collect repository-wide info about [Archivematica][am-1] Archival

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+# Validate this file:
+#   curl --data-binary @codecov.yml https://codecov.io/validate
+
+comment: off
+
+coverage:
+  precision: 2
+  round: down
+  range: "25...100"
+  status:
+    project:
+      default:
+        threshold: 25%
+        if_not_found: success
+    patch:
+      default:
+        threshold: 25%
+        if_not_found: success

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,5 @@
 
 flake8==3.8.3
 pytest==5.4.3
+pytest_cov==2.11.1
 pytest_mock==3.3.1


### PR DESCRIPTION
This modifies the `test` GitHub CI workflow to generate coverage reports for all the `tox` environments.

These reports are then uploaded and processed in [codecov.io](https://app.codecov.io/gh/artefactual-labs/AIPscan).

The `codecov.yml` configuration is a copy from enduro.

Connected to https://github.com/archivematica/Issues/issues/1434