### PR TITLE
Add defensive check for ingestion events to prevent 500 errors with Agent-Transfers report

### DIFF
--- a/AIPscan/Data/report_data.py
+++ b/AIPscan/Data/report_data.py
@@ -330,6 +330,10 @@ def agents_transfers(storage_service_id):
             .filter(File.aip_id == aip.id, Event.type == EVENT_TYPE)
             .first()
         )
+        # This defensive check is necessary for now because of packages that
+        # are deleted after extraction. See issue #104 for details.
+        if event is None:
+            continue
         log_line = {}
         log_line[fields.FIELD_AIP_UUID] = aip.uuid
         log_line[fields.FIELD_AIP_NAME] = aip.transfer_name

--- a/AIPscan/Data/tests/conftest.py
+++ b/AIPscan/Data/tests/conftest.py
@@ -208,6 +208,46 @@ def app_with_populated_files(scope="package"):
 
 
 @pytest.fixture
+def app_with_populated_files_no_ingestion_event(scope="package"):
+    """Fixture with pre-populated data.
+
+    This fixture is used to create expected state which is then used to
+    test the Data.aips_by_file_format and Data.aips_by_puid endpoints.
+    """
+    app = create_app("test")
+    with app.app_context():
+        db.create_all()
+
+        storage_service = _create_test_storage_service()
+        fetch_job = _create_test_fetch_job(storage_service_id=storage_service.id)
+
+        _ = _create_test_aip(
+            uuid="111111111111-1111-1111-11111111",
+            create_date=AIP_CREATION_TIME,
+            storage_service_id=storage_service.id,
+            fetch_job_id=fetch_job.id,
+        )
+
+        _create_test_file(
+            file_type=FileType.original,
+            size=ORIGINAL_FILE_SIZE,
+            puid=TIFF_PUID,
+            file_format=TIFF_FILE_FORMAT,
+        )
+
+        _ = _create_test_file(
+            file_type=FileType.preservation,
+            size=PRESERVATION_FILE_SIZE,
+            puid=TIFF_PUID,
+            file_format=TIFF_FILE_FORMAT,
+        )
+
+        yield app
+
+        db.drop_all()
+
+
+@pytest.fixture
 def app_with_populated_format_versions(scope="package"):
     """Fixture with pre-populated data.
 

--- a/AIPscan/Data/tests/test_agents_transfers.py
+++ b/AIPscan/Data/tests/test_agents_transfers.py
@@ -54,3 +54,24 @@ def test_agents_transfers(
     assert ingests[0]["User"] == "user one"
     assert ingests[0]["IngestStartDate"] == str(ingest_date)
     assert ingests[0]["IngestFinishDate"] == str(aip_creation_date)
+
+
+@pytest.mark.parametrize(
+    "storage_id, storage_name, number_of_ingests",
+    [
+        # Simple transfer with limited amount of data from the DB.
+        (1, "test storage service", 0)
+    ],
+)
+def test_agents_transfers_no_ingestion_event(
+    app_with_populated_files_no_ingestion_event,
+    storage_id,
+    storage_name,
+    number_of_ingests,
+):
+    """Test that lack of ingestion event doesn't throw error."""
+
+    report = report_data.agents_transfers(storage_service_id=storage_id)
+
+    assert report["StorageName"] == storage_name
+    assert len(report["Ingests"]) == number_of_ingests


### PR DESCRIPTION
This is a temporary solution to prevent `AttributeErrors` on `None` ingestion events (a current result of packages deleted after extraction in Archivematica) from preventing display of the Agent-Transfers report, until a better representation of deleted packages is possible in the AIPscan database.

Connected to #104