### PR TITLE
Gracefully handle bad Storage Service connections

### DIFF
--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -179,7 +179,7 @@ def workflow_coordinator(
     db.session.commit()
 
 
-def _make_request(request_url, request_url_without_api_key):
+def make_request(request_url, request_url_without_api_key):
     """Make our request to the storage service and return a valid
     response to our caller or raise a TaskError for celery.
     """
@@ -215,7 +215,7 @@ def package_lists_request(self, apiUrl, timestamp, packages_directory):
         request_url,
     ) = format_api_url_with_limit_offset(apiUrl)
     # First packages request.
-    packages = _make_request(request_url, request_url_without_api_key)
+    packages = make_request(request_url, request_url_without_api_key)
     packages_count = 1
     # Calculate how many package list files will be downloaded based on
     # total number of packages and the download limit
@@ -232,7 +232,7 @@ def package_lists_request(self, apiUrl, timestamp, packages_directory):
     write_packages_json(packages_count, packages, packages_directory)
     while next_url is not None:
         next_request = "{}{}".format(base_url, next_url)
-        next_packages = _make_request(next_request, request_url_without_api_key)
+        next_packages = make_request(next_request, request_url_without_api_key)
         packages_count += 1
         write_packages_json(packages_count, next_packages, packages_directory)
         next_url = next_packages.get(META, {}).get(NEXT, None)

--- a/AIPscan/Aggregator/tests/__init__.py
+++ b/AIPscan/Aggregator/tests/__init__.py
@@ -1,0 +1,19 @@
+import json
+
+RESPONSE_DICT = {"key": "value"}
+VALID_JSON = json.dumps(RESPONSE_DICT)
+INVALID_JSON = "test"
+
+REQUEST_URL_WITHOUT_API_KEY = "http://test-archivematica.example.com:8000"
+REQUEST_URL = REQUEST_URL_WITHOUT_API_KEY + "?user=test&api_key=test"
+
+
+class MockResponse:
+    """Mock requests.Response class."""
+
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self.data = data
+
+    def json(self):
+        return json.loads(self.data)

--- a/AIPscan/Aggregator/tests/test_views.py
+++ b/AIPscan/Aggregator/tests/test_views.py
@@ -1,0 +1,35 @@
+import pytest
+from flask import current_app
+
+from AIPscan.Aggregator.tasks import TaskError
+from AIPscan.Aggregator.views import _test_storage_service_connection
+
+API_URL = {
+    "baseUrl": "http://test-url",
+    "userName": "test",
+    "apiKey": "test",
+    "offset": "10",
+    "limit": "0",
+}
+
+
+def test__test_storage_service_connection(mocker):
+    """Test that invalid SS connection raises ConnectionError."""
+    make_request = mocker.patch("AIPscan.Aggregator.views.tasks.make_request")
+    make_request.side_effect = TaskError("Bad response from server")
+
+    with pytest.raises(ConnectionError):
+        _test_storage_service_connection(API_URL)
+
+
+def test_new_fetch_job_bad_connection(app_with_populated_files, mocker):
+    """Verify Celery tasks don't run wihtout a Storage Service connection."""
+    task = mocker.patch("AIPscan.Aggregator.views.tasks.workflow_coordinator.delay")
+    test_storage_service_conn = mocker.patch(
+        "AIPscan.Aggregator.views._test_storage_service_connection"
+    )
+    test_storage_service_conn.side_effect = ConnectionError("Bad response from server")
+    with current_app.test_client() as test_client:
+        response = test_client.post("/aggregator/new_fetch_job/1")
+        task.assert_not_called()
+        assert response.status_code == 400

--- a/AIPscan/static/js/tasks.js
+++ b/AIPscan/static/js/tasks.js
@@ -9,10 +9,10 @@ function new_fetch_job(storageServiceId){
       $('#console').append('<div class="log">Downloading package lists</div>')
       var showcount = false
       package_list_task_status(data["taskId"], showcount, data["fetchJobId"]);
-      },
+    },
     error: function() {
-      alert('Unexpected error');
-      }
+      alert('Storage Service connection error. Check URL and credentials.');
+    }
   });
 }
 


### PR DESCRIPTION
Connected to #111 

This PR checks the Storage Service credentials and ensures there is a good connection before kicking off a Fetch Job's Celery tasks. This prevents the most common reason for AIPscan's Celery tasks to hang and provides quick feedback in the UI if the Storage Service URL, username, or API key are incorrect, or if the Storage Service can't be reached:

![image](https://user-images.githubusercontent.com/6758804/116301276-df9fd580-a76d-11eb-8a45-0710908275f0.png)
