### PR TITLE
Avoid AttributeError during parsing of preservation files unconnected to an original (#129)

### DIFF
--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -228,7 +228,12 @@ def _add_normalization_date(file_id):
         db.session.commit()
 
 
-def _add_file(file_type, fs_entry, aip_id):
+def _get_original_file(related_uuid):
+    """Get original file related to preservation derivative."""
+    return File.query.filter_by(uuid=related_uuid, file_type=FileType.original).first()
+
+
+def create_file_object(file_type, fs_entry, aip_id):
     """Add file to database
 
     :param file_type: models.FileType enum
@@ -239,8 +244,9 @@ def _add_file(file_type, fs_entry, aip_id):
 
     original_file_id = None
     if file_type is FileType.preservation:
-        original_file = File.query.filter_by(uuid=file_info["related_uuid"]).first()
-        original_file_id = original_file.id
+        original_file = _get_original_file(file_info["related_uuid"])
+        if original_file:
+            original_file_id = original_file.id
 
     new_file = File(
         name=file_info.get("name"),
@@ -298,8 +304,8 @@ def process_aip_data(aip, mets):
     # when we parse preservation and derivative files.
     original_files = [file_ for file_ in all_files if file_.use == "original"]
     for file_ in original_files:
-        _add_file(FileType.original, file_, aip.id)
+        create_file_object(FileType.original, file_, aip.id)
 
     preservation_files = [file_ for file_ in all_files if file_.use == "preservation"]
     for file_ in preservation_files:
-        _add_file(FileType.preservation, file_, aip.id)
+        create_file_object(FileType.preservation, file_, aip.id)


### PR DESCRIPTION
Connected to #129 

This fixes a bug where an `AttributeError` was raised when parsing preservation files that are unconnected to an original file (which is possible when using manual normalization workflows in Archivematica) from the AIP METS into the database.