### PR TITLE
Fix reports table alignment

### DIFF
--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -35,7 +35,7 @@
     <!-- Original file formats indicates data has been fetched for this Storage Service -->
     {% if original_file_formats %}
 
-    <table class="table table-striped table-bordered" style="margin: 1.25rem;">
+    <table class="table table-striped table-bordered" style="margin-top: 1.25rem;">
 
         <tr>
             <th>Report</th>


### PR DESCRIPTION
A very small CSS tweak to align the report selection table properly within the "Reports" page and stop Tessa from wincing every time she loads the page ;)

Before:

![image](https://user-images.githubusercontent.com/6758804/117312602-29b24680-ae53-11eb-82a7-6ec3e6c37014.png)

After:

![image](https://user-images.githubusercontent.com/6758804/117312681-3afb5300-ae53-11eb-9a6b-a9193ea7da60.png)
