### PR TITLE
Remove duplicate File Format count row in Reports page

### DIFF
--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -44,12 +44,6 @@
         </tr>
 
         <tr>
-            <td>File format count</td>
-            <td>Uses date fields</td>
-            <td><a href=""><button type="button" id="report1a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a><a href=""><button type="button" id="report1b" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Pie Chart</button></a><a href=""><button type="button" id="report1c" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Scatter Plot</button></a></td>
-        </tr>
-
-        <tr>
             <td>AIP contents</td>
             <td></td>
             <td><a href="#"><button type="button" id="report2a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>


### PR DESCRIPTION
This PR removes an entry erroneously added in the Reports selection page table during resolution of a merge conflict.