### PR TITLE
Obfuscate Storage Service API key

### DIFF
--- a/AIPscan/Aggregator/forms.py
+++ b/AIPscan/Aggregator/forms.py
@@ -3,13 +3,16 @@
 from flask_wtf import FlaskForm
 from wtforms import BooleanField, StringField
 from wtforms.validators import DataRequired
+from wtforms.widgets import PasswordInput
 
 
 class StorageServiceForm(FlaskForm):
     name = StringField("Name", validators=[DataRequired()])
     url = StringField("URL", validators=[DataRequired()])
     user_name = StringField("User name", validators=[DataRequired()])
-    api_key = StringField("API key", validators=[DataRequired()])
+    api_key = StringField(
+        "API key", validators=[DataRequired()], widget=PasswordInput(hide_value=False)
+    )
     download_limit = StringField("Download limit", default="20")
     download_offset = StringField("Download offset", default="0")
     default = BooleanField("Default")

--- a/AIPscan/Aggregator/templates/storage_service.html
+++ b/AIPscan/Aggregator/templates/storage_service.html
@@ -11,7 +11,15 @@
   <tr><td width=20%><strong>Name</strong></td><td>{{ storage_service.name }}</td></tr>
   <tr><td width=20%><strong>URL</strong></td><td>{{ storage_service.url}}</td></tr>
   <tr><td width=20%><strong>User name</strong></td><td>{{ storage_service.user_name}}</td></tr>
-  <tr><td width=20%><strong>API key</strong></td><td>{{ storage_service.api_key}}</td></tr>
+  <tr>
+    <td width=20%>
+      <strong>API key</strong>
+    </td>
+    <td>
+      <span id="apikey">&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull; </span>
+      <i id="apikeyBtn" class="fa fa-eye" aria-hidden="true"></i>
+    </td>
+  </tr>
   <tr><td width=20%><strong>Download limit</strong></td><td>{{ storage_service.download_limit}}</td></tr>
   <tr><td width=20%><strong>Download offset</strong></td><td>{{ storage_service.download_offset}}</td></tr>
   <tr><td width=20%><strong>Default service</strong></td><td>{{ storage_service.default}}</td></tr>
@@ -63,12 +71,23 @@
 <button type="button" class="btn btn-success" style="margin-top: 20px;" id="newfetchjob">New fetch job</button>
 
 
-
 <script>
 $(document).ready(function(){
   $('#newfetchjob').on('click', function () {
     new_fetch_job({{ storage_service.id }});
-    });
+  });
+
+  // Handle API key visibility
+  let apiKeyVisible = false;
+  let apiKeyHiddenText = '&bull;'.repeat(16)
+  $('#apikeyBtn').on('click', function () {
+    apiKeyVisible = !apiKeyVisible;
+    if (apiKeyVisible === true ) {
+      $('#apikey').text('{{ storage_service.api_key}}');
+    } else {
+      $('#apikey').html(apiKeyHiddenText);
+    }
+  });
 })
 </script>
 


### PR DESCRIPTION
Connected to #109

The Storage Service API key is now hidden by default in the Storage Service detail screen:

![image](https://user-images.githubusercontent.com/6758804/117368983-49b52a80-ae92-11eb-9c8e-d9f9b84c1e75.png)

Clicking on the eye toggles the API key's visibility:

![image](https://user-images.githubusercontent.com/6758804/117369022-55085600-ae92-11eb-8fbb-56348d197ccb.png)

The API key is additionally obfuscated in the edit form, which now functions as a password input field:

![image](https://user-images.githubusercontent.com/6758804/117369123-78330580-ae92-11eb-9c77-bc4ee8c6fc79.png)

