### PR TITLE
Add Pipeline model and dashboard URL link to AIPscan

### DIFF
--- a/AIPscan/Aggregator/task_helpers.py
+++ b/AIPscan/Aggregator/task_helpers.py
@@ -48,6 +48,7 @@ def process_package_object(package_obj):
     REPL = "replicated_package"
     CURRENT_LOCATION = "current_location"
     CURRENT_PATH = "current_path"
+    ORIGIN_PIPELINE = "origin_pipeline"
     UUID = "uuid"
 
     PKG_AIP = "AIP"
@@ -71,6 +72,7 @@ def process_package_object(package_obj):
     package.uuid = package_obj.get(UUID)
     package.current_location = package_obj.get(CURRENT_LOCATION)
     package.current_path = package_obj.get(CURRENT_PATH)
+    package.origin_pipeline = package_obj.get(ORIGIN_PIPELINE)
 
     return package
 
@@ -110,10 +112,10 @@ def get_mets_url(api_url, package_uuid, path_to_mets):
     return mets_url
 
 
-def get_location_url(api_url, current_location):
+def get_storage_service_api_url(api_url, api_path):
     """Return URL to fetch location infofrom Storage Service."""
     base_url = api_url.get("baseUrl", "").rstrip("/")
-    request_url_without_api_key = "{}{}".format(base_url, current_location).rstrip("/")
+    request_url_without_api_key = "{}{}".format(base_url, api_path).rstrip("/")
     user_name = api_url.get("userName")
     api_key = api_url.get("apiKey", "")
     request_url = "{}?username={}&api_key={}".format(

--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -324,8 +324,6 @@ def get_mets(
         )
         database_helpers.delete_aip_object(previous_aip)
 
-    # TODO: ADD ORIGIN PIPELINE!
-
     aip = database_helpers.create_aip_object(
         package_uuid=package_uuid,
         transfer_name=original_name,

--- a/AIPscan/Aggregator/tests/test_database_helpers.py
+++ b/AIPscan/Aggregator/tests/test_database_helpers.py
@@ -7,8 +7,8 @@ import metsrw
 import pytest
 
 from AIPscan.Aggregator import database_helpers
-from AIPscan.conftest import STORAGE_LOCATION_1_CURRENT_LOCATION
-from AIPscan.models import AIP, Agent, File, FileType, StorageLocation
+from AIPscan.conftest import ORIGIN_PIPELINE, STORAGE_LOCATION_1_CURRENT_LOCATION
+from AIPscan.models import AIP, Agent, File, FileType, Pipeline, StorageLocation
 
 FIXTURES_DIR = "fixtures"
 
@@ -57,6 +57,21 @@ def test_create_storage_location_object(app_instance):
     assert storage_location.storage_service_id == STORAGE_SERVICE_ID
 
 
+def test_create_pipeline_object(app_instance):
+    LOCATION_UUID = str(uuid.uuid4())
+    ORIGIN_PIPELINE = "/api/v2/pipeline/{}".format(LOCATION_UUID)
+    DASHBOARD_URL = "http://tessas-am-dashboard.example.com"
+
+    database_helpers.create_pipeline_object(
+        origin_pipeline=ORIGIN_PIPELINE, dashboard_url=DASHBOARD_URL
+    )
+
+    pipeline = Pipeline.query.filter_by(origin_pipeline=ORIGIN_PIPELINE).first()
+    assert pipeline is not None
+    assert pipeline.origin_pipeline == ORIGIN_PIPELINE
+    assert pipeline.dashboard_url == DASHBOARD_URL
+
+
 def test_create_aip(app_instance):
     """Test AIP creation."""
     PACKAGE_UUID = str(uuid.uuid4())
@@ -64,6 +79,7 @@ def test_create_aip(app_instance):
     STORAGE_SERVICE_ID = 1
     STORAGE_LOCATION_ID = 1
     FETCH_JOB_ID = 1
+    ORIGIN_PIPELINE_ID = 1
 
     database_helpers.create_aip_object(
         package_uuid=PACKAGE_UUID,
@@ -73,6 +89,7 @@ def test_create_aip(app_instance):
         storage_service_id=STORAGE_SERVICE_ID,
         storage_location_id=STORAGE_LOCATION_ID,
         fetch_job_id=FETCH_JOB_ID,
+        origin_pipeline_id=ORIGIN_PIPELINE_ID,
     )
 
     aip = AIP.query.filter_by(uuid=PACKAGE_UUID).first()
@@ -80,6 +97,7 @@ def test_create_aip(app_instance):
     assert aip.transfer_name == TRANSFER_NAME
     assert aip.storage_service_id == STORAGE_SERVICE_ID
     assert aip.fetch_job_id == FETCH_JOB_ID
+    assert aip.origin_pipeline_id == ORIGIN_PIPELINE_ID
 
 
 def test_delete_aip(app_instance):
@@ -94,6 +112,7 @@ def test_delete_aip(app_instance):
         storage_service_id=1,
         storage_location_id=1,
         fetch_job_id=1,
+        origin_pipeline_id=1,
     )
 
     aip = AIP.query.filter_by(uuid=PACKAGE_UUID).first()
@@ -275,3 +294,32 @@ def test_create_or_update_storage_location(
         create_storage_location_object.assert_called_once()
     else:
         assert storage_location.description == new_description
+
+
+@pytest.mark.parametrize(
+    "origin_pipeline, new_url, pipeline_created",
+    [
+        # Create Pipeline if matching one doesn't exist.
+        ("/api/v2/pipeline/new-pipeline/", "", True),
+        # Update Pipeline's dashboard URL if already exists.
+        (ORIGIN_PIPELINE, "http://new-url.example.com", False),
+    ],
+)
+def test_create_or_update_pipeline(
+    storage_locations, mocker, origin_pipeline, new_url, pipeline_created
+):
+    """Test that Storage Locations are created or updated as expected."""
+    make_request = mocker.patch("AIPscan.Aggregator.tasks.make_request")
+    make_request.return_value = {"remote_name": new_url}
+    create_pipeline_object = mocker.patch(
+        "AIPscan.Aggregator.database_helpers.create_pipeline_object"
+    )
+
+    pipeline = database_helpers.create_or_update_pipeline(
+        origin_pipeline=origin_pipeline, api_url={}
+    )
+
+    if pipeline_created:
+        create_pipeline_object.assert_called_once()
+    else:
+        assert pipeline.dashboard_url == new_url

--- a/AIPscan/Aggregator/tests/test_task_helpers.py
+++ b/AIPscan/Aggregator/tests/test_task_helpers.py
@@ -110,11 +110,13 @@ def test_get_mets_url(api_url, package_uuid, path_to_mets, result):
         )
     ],
 )
-def test_get_location_url(
+def test_get_storage_service_api_url(
     api_url, current_location, expected_url, expected_url_without_api_key
 ):
-    """Ensure construction of URL to fetch location information."""
-    url, url_without_secrets = task_helpers.get_location_url(api_url, current_location)
+    """Ensure construction of URL to fetch Resource information."""
+    url, url_without_secrets = task_helpers.get_storage_service_api_url(
+        api_url, current_location
+    )
     assert url == expected_url
     assert url_without_secrets == expected_url_without_api_key
 
@@ -178,6 +180,7 @@ def packages():
                 current_path="9194/0daf/5c33/4670/bfc8/9108/f32b/ca7b/repl-91940daf-5c33-4670-bfc8-9108f32bca7b.7z",
                 uuid="91940daf-5c33-4670-bfc8-9108f32bca7b",
                 current_location="/api/v2/location/a083fd8c-8b5a-4ece-acc4-c6388ade3d56/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -188,6 +191,7 @@ def packages():
                 current_path="9021/92d9/6232/4d5f/b6c4/dfa7/b873/3960/repl-902192d9-6232-4d5f-b6c4-dfa7b8733960.7z",
                 uuid="902192d9-6232-4d5f-b6c4-dfa7b8733960",
                 current_location="/api/v2/location/a82c7f40-34f5-4442-a408-cbcf16f0c1cf/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -198,6 +202,7 @@ def packages():
                 current_path="594a/03f3/d8eb/4c83/affd/aefa/f75d/53cc/delete_me-594a03f3-d8eb-4c83-affd-aefaf75d53cc.7z",
                 uuid="594a03f3-d8eb-4c83-affd-aefaf75d53cc",
                 current_location="/api/v2/location/a083fd8c-8b5a-4ece-acc4-c6388ade3d56/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -207,6 +212,7 @@ def packages():
                 current_path="e422/c724/834c/4164/a7be/4c88/1043/a531/normalize-e422c724-834c-4164-a7be-4c881043a531.7z",
                 uuid="e422c724-834c-4164-a7be-4c881043a531",
                 current_location="/api/v2/location/a083fd8c-8b5a-4ece-acc4-c6388ade3d56/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -216,6 +222,7 @@ def packages():
                 current_path="583c/009c/4255/44b9/8868/f57e/4bad/e93c/normal_aip-583c009c-4255-44b9-8868-f57e4bade93c.7z",
                 uuid="583c009c-4255-44b9-8868-f57e4bade93c",
                 current_location="/api/v2/location/a083fd8c-8b5a-4ece-acc4-c6388ade3d56/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -225,6 +232,7 @@ def packages():
                 current_path="846f/ca2b/0919/4673/804c/0f62/6a30/cabd/uncomp-846fca2b-0919-4673-804c-0f626a30cabd",
                 uuid="846fca2b-0919-4673-804c-0f626a30cabd",
                 current_location="/api/v2/location/a083fd8c-8b5a-4ece-acc4-c6388ade3d56/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -234,6 +242,7 @@ def packages():
                 current_path="1555/04f5/98dd/48d1/9e97/83bc/f0a5/efa2/normcore-59f70134-eeca-4886-888e-b2013a08571e",
                 uuid="155504f5-98dd-48d1-9e97-83bcf0a5efa2",
                 current_location="/api/v2/location/7e99c7b0-bd30-4d49-b173-3cb59a32f0c5/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -243,6 +252,7 @@ def packages():
                 current_path="59f7/0134/eeca/4886/888e/b201/3a08/571e/normcore-59f70134-eeca-4886-888e-b2013a08571e",
                 uuid="59f70134-eeca-4886-888e-b2013a08571e",
                 current_location="/api/v2/location/a083fd8c-8b5a-4ece-acc4-c6388ade3d56/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
         (
@@ -252,6 +262,7 @@ def packages():
                 current_path="originals/backlog-fbdcd607-270e-4dff-9a01-d11b7c2a0200",
                 uuid="fbdcd607-270e-4dff-9a01-d11b7c2a0200",
                 current_location="/api/v2/location/7fe31789-90e0-4ad3-a669-18517737fc25/",
+                origin_pipeline="/api/v2/pipeline/dbb92514-1572-4a81-87ee-06408672e7a6/",
             ),
         ),
     ],

--- a/AIPscan/Aggregator/tests/test_tasks.py
+++ b/AIPscan/Aggregator/tests/test_tasks.py
@@ -54,6 +54,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     storage_location = test_helpers.create_test_storage_location(
         storage_service_id=storage_service.id
     )
+    pipeline = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
 
     get_storage_location = mocker.patch(
         "AIPscan.Aggregator.database_helpers.create_or_update_storage_location"
@@ -73,7 +74,6 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     get_mets(
         package_uuid=package_uuid,
         relative_path_to_mets="test",
-        current_location="/api/v2/test-location/",
         api_url=api_url,
         timestamp_str=datetime.now()
         .replace(microsecond=0)
@@ -82,6 +82,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
         storage_service_id=storage_service.id,
         storage_location_id=storage_location.id,
         fetch_job_id=fetch_job1.id,
+        origin_pipeline_id=pipeline.id,
     )
     aips = _get_aips(storage_service.id)
     assert len(aips) == 1
@@ -96,7 +97,6 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     get_mets(
         package_uuid=package_uuid,
         relative_path_to_mets="test",
-        current_location="/api/v2/test-location/",
         api_url=api_url,
         timestamp_str=datetime.now()
         .replace(microsecond=0)
@@ -105,6 +105,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
         storage_service_id=storage_service.id,
         storage_location_id=storage_location.id,
         fetch_job_id=fetch_job2.id,
+        origin_pipeline_id=pipeline.id,
     )
     aips = _get_aips(storage_service.id)
     assert len(aips) == 1
@@ -121,7 +122,6 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     get_mets(
         package_uuid=package_uuid,
         relative_path_to_mets="test",
-        current_location="/api/v2/test-location/",
         api_url=api_url,
         timestamp_str=datetime.now()
         .replace(microsecond=0)
@@ -130,6 +130,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
         storage_service_id=storage_service.id,
         storage_location_id=storage_location.id,
         fetch_job_id=fetch_job3.id,
+        origin_pipeline_id=pipeline.id,
     )
     aips = _get_aips(storage_service.id)
     assert len(aips) == 1

--- a/AIPscan/Aggregator/types.py
+++ b/AIPscan/Aggregator/types.py
@@ -27,6 +27,7 @@ class StorageServicePackage(object):
         UUID = "uuid"
         CURRENT_LOCATION = "current_location"
         CURRENT_PATH = "current_path"
+        ORIGIN_PIPELINE = "origin_pipeline"
 
         self.deleted = False
         self.replica = False
@@ -36,6 +37,7 @@ class StorageServicePackage(object):
         self.uuid = None
         self.current_location = None
         self.current_path = None
+        self.origin_pipeline = None
 
         if kwargs:
             self.deleted = kwargs.get(DELETED, self.deleted)
@@ -46,6 +48,7 @@ class StorageServicePackage(object):
             self.uuid = kwargs.get(UUID, self.uuid)
             self.current_location = kwargs.get(CURRENT_LOCATION, self.current_location)
             self.current_path = kwargs.get(CURRENT_PATH, self.uuid)
+            self.origin_pipeline = kwargs.get(ORIGIN_PIPELINE, self.origin_pipeline)
 
     def __repr__(self):
         ret = "aip: '{}'; dip: '{}'; sip: '{}'; deleted: '{}'; replica: '{}';".format(
@@ -71,6 +74,8 @@ class StorageServicePackage(object):
         if self.current_location != other.current_location:
             ret = False
         if self.current_path != other.current_path:
+            ret = False
+        if self.origin_pipeline != other.origin_pipeline:
             ret = False
         return ret
 

--- a/AIPscan/Data/tests/__init__.py
+++ b/AIPscan/Data/tests/__init__.py
@@ -70,4 +70,5 @@ MOCK_AIP = AIP(
     storage_service_id=MOCK_STORAGE_SERVICE_ID,
     storage_location_id=MOCK_STORAGE_LOCATION_ID,
     fetch_job_id=1,
+    origin_pipeline_id=1,
 )

--- a/AIPscan/Reporter/templates/aip.html
+++ b/AIPscan/Reporter/templates/aip.html
@@ -15,6 +15,8 @@
   <br>
   Storage location: {{ storage_location.description }} ({{ storage_location.uuid }})
   <br>
+  Origin pipeline: <a href="{{ origin_pipeline.dashboard_url }}">{{ origin_pipeline.dashboard_url }}</a>
+  <br>
   Creation date: {{ aip.create_date }}
   <br>
   Originals: {{ original_file_count }}

--- a/AIPscan/Reporter/views.py
+++ b/AIPscan/Reporter/views.py
@@ -15,6 +15,7 @@ from AIPscan.models import (
     FetchJob,
     File,
     FileType,
+    Pipeline,
     StorageLocation,
     StorageService,
 )
@@ -112,6 +113,7 @@ def view_aip(aip_id):
     original_files = File.query.filter_by(
         aip_id=aip.id, file_type=FileType.original
     ).all()
+    origin_pipeline = Pipeline.query.get(aip.origin_pipeline_id)
     for file_ in original_files:
         original = {}
         original["id"] = file_.id
@@ -138,6 +140,7 @@ def view_aip(aip_id):
         originals=originals,
         original_file_count=original_file_count,
         preservation_file_count=preservation_file_count,
+        origin_pipeline=origin_pipeline,
     )
 
 

--- a/AIPscan/conftest.py
+++ b/AIPscan/conftest.py
@@ -40,6 +40,9 @@ ORIGINAL_FILE_1_UUID = "333333333333-3333-3333-33333333"
 ORIGINAL_FILE_2_NAME = "original-file-2.jpg"
 ORIGINAL_FILE_2_UUID = "444444444444-4444-4444-44444444"
 
+ORIGIN_PIPELINE_UUID = "777777777777-7777-7777-77777777"
+ORIGIN_PIPELINE = "/api/v2/pipeline/{}/".format(ORIGIN_PIPELINE_UUID)
+
 PRESERVATION_FILE_1_NAME = "preservation-file-1.tif"
 PRESERVATION_FILE_2_NAME = "preservation-file-2.tif"
 
@@ -115,6 +118,7 @@ def app_with_populated_files(scope="package"):
         storage_location = test_helpers.create_test_storage_location(
             storage_service_id=storage_service.id
         )
+        _ = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
         fetch_job = test_helpers.create_test_fetch_job(
             storage_service_id=storage_service.id
         )
@@ -171,6 +175,7 @@ def app_with_populated_files_no_ingestion_event(scope="package"):
         storage_location = test_helpers.create_test_storage_location(
             storage_service_id=storage_service.id
         )
+        _ = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
         fetch_job = test_helpers.create_test_fetch_job(
             storage_service_id=storage_service.id
         )
@@ -217,6 +222,7 @@ def app_with_populated_format_versions(scope="package"):
         storage_location = test_helpers.create_test_storage_location(
             storage_service_id=storage_service.id
         )
+        _ = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
         fetch_job = test_helpers.create_test_fetch_job(
             storage_service_id=storage_service.id
         )
@@ -289,6 +295,7 @@ def preservation_derivatives(scope="package"):
         storage_location = test_helpers.create_test_storage_location(
             storage_service_id=storage_service.id
         )
+        _ = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
         fetch_job = test_helpers.create_test_fetch_job(
             storage_service_id=storage_service.id
         )
@@ -370,6 +377,7 @@ def aip_contents(scope="package"):
         storage_location = test_helpers.create_test_storage_location(
             storage_service_id=storage_service.id
         )
+        _ = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
         fetch_job = test_helpers.create_test_fetch_job(
             storage_service_id=storage_service.id
         )
@@ -427,6 +435,9 @@ def storage_locations(scope="package"):
             storage_service_id=storage_service.id,
             current_location=STORAGE_LOCATION_2_CURRENT_LOCATION,
             description=STORAGE_LOCATION_2_DESCRIPTION,
+        )
+        _ = test_helpers.create_test_pipeline(
+            origin_pipeline=ORIGIN_PIPELINE, storage_service_id=storage_service.id
         )
         fetch_job = test_helpers.create_test_fetch_job(
             storage_service_id=storage_service.id

--- a/AIPscan/test_helpers.py
+++ b/AIPscan/test_helpers.py
@@ -10,6 +10,7 @@ from AIPscan.models import (
     FetchJob,
     File,
     FileType,
+    Pipeline,
     StorageLocation,
     StorageService,
 )
@@ -66,6 +67,16 @@ def create_test_storage_location(**kwargs):
     return storage_location
 
 
+def create_test_pipeline(**kwargs):
+    """Create and return a test Pipeline with overridable defaults."""
+    pipeline = Pipeline(
+        origin_pipeline=kwargs.get("origin_pipeline", "/api/v2/pipeline/test-pipeline"),
+        dashboard_url=kwargs.get("dashboard_url", "http://example.com"),
+    )
+    _add_test_object_to_db(pipeline)
+    return pipeline
+
+
 def create_test_aip(**kwargs):
     """Create and return a test AIP with overridable defaults."""
     aip = AIP(
@@ -76,6 +87,7 @@ def create_test_aip(**kwargs):
         storage_service_id=kwargs.get("storage_service_id", 1),
         storage_location_id=kwargs.get("storage_location_id", 1),
         fetch_job_id=kwargs.get("fetch_job_id", 1),
+        origin_pipeline_id=kwargs.get("origin_pipeline_id", 1),
     )
     _add_test_object_to_db(aip)
     return aip

--- a/AIPscan/tests/test_models.py
+++ b/AIPscan/tests/test_models.py
@@ -20,9 +20,11 @@ from AIPscan.models import StorageLocation, StorageService
 
 VALID_UUID = "3ce6fbcb-cdfc-4cca-97e4-d19a469ca043"
 VALID_CURRENT_LOCATION = "/api/v2/location/{}/".format(VALID_UUID)
+VALID_ORIGIN_PIPELINE = "/api/v2/pipeline/{}/".format(VALID_UUID)
 
 INVALID_UUID = "not-a-uuid"
 INVALID_CURRENT_LOCATION = "/api/v2/location/{}/".format(INVALID_UUID)
+INVALID_ORIGIN_PIPELINE = "/api/v2/pipeline/{}/".format(INVALID_UUID)
 
 
 def test_new_storage_service(app_with_populated_files):
@@ -242,3 +244,18 @@ def test_storage_location_unique_puids(
 
     assert storage_location.unique_original_puids == original_puids
     assert storage_location.unique_preservation_puids == preservation_puids
+
+
+@pytest.mark.parametrize(
+    "origin_pipeline, expected_uuid",
+    [
+        # Test that UUID is returned for valid current location.
+        (VALID_ORIGIN_PIPELINE, VALID_UUID),
+        # Test that None is returned for invalid current location.
+        (INVALID_ORIGIN_PIPELINE, None),
+    ],
+)
+def test_pipeline_uuid(app_instance, origin_pipeline, expected_uuid):
+    """Test Storage Location uuid property."""
+    pipeline = test_helpers.create_test_pipeline(origin_pipeline=origin_pipeline)
+    assert pipeline.uuid == expected_uuid


### PR DESCRIPTION
Connected to #136

This PR adds a new `Pipeline` model with fields `origin_pipeline` and `dashboard_url` that is connected to the `Storage Service` and `AIP` models via foreign key. It also adds a link to the origin dashboard on the AIP detail page:

![image](https://user-images.githubusercontent.com/6758804/121251623-155bd200-c875-11eb-9ea4-bb4d9a3aac7e.png)

Updated ERD:

![relationships real large](https://user-images.githubusercontent.com/6758804/121383919-d0d44300-c915-11eb-8fa9-e1afe8aeef5d.png)