### PR TITLE
Rework AIP Contents report

### DIFF
--- a/AIPscan/API/namespace_data.py
+++ b/AIPscan/API/namespace_data.py
@@ -12,7 +12,7 @@ from flask_restx import Namespace, Resource
 
 from AIPscan.API import fields
 from AIPscan.Data import data
-from AIPscan.helpers import parse_bool
+from AIPscan.helpers import parse_bool, parse_datetime_bound
 
 api = Namespace("data", description="Retrieve data from AIPscan to shape as you desire")
 
@@ -39,14 +39,30 @@ class AIPList(Resource):
                 "in": "query",
                 "type": "int",
             },
+            fields.FIELD_START_DATE: {
+                "description": "AIP creation start date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_END_DATE: {
+                "description": "AIP creation end date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
         },
     )
     def get(self, storage_service_id):
         """Return data on AIPs and the file formats they contain."""
         original_files = parse_bool(request.args.get(fields.FIELD_ORIGINAL_FILES, True))
         storage_location_id = request.args.get(fields.FIELD_STORAGE_LOCATION)
+        start_date = parse_datetime_bound(request.args.get(fields.FIELD_START_DATE))
+        end_date = parse_datetime_bound(
+            request.args.get(fields.FIELD_END_DATE), upper=True
+        )
         return data.aip_file_format_overview(
             storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
             original_files=original_files,
             storage_location_id=storage_location_id,
         )

--- a/AIPscan/Data/tests/test_aip_contents.py
+++ b/AIPscan/Data/tests/test_aip_contents.py
@@ -1,0 +1,174 @@
+import pytest
+
+from AIPscan.conftest import (
+    STORAGE_LOCATION_1_DESCRIPTION,
+    STORAGE_LOCATION_2_DESCRIPTION,
+)
+from AIPscan.Data import data, fields
+from AIPscan.helpers import parse_datetime_bound
+
+DATE_BEFORE_AIP_1 = "2019-01-01"
+DATE_AFTER_AIP_1 = "2020-01-02"
+DATE_BEFORE_AIP_2 = "2020-05-30"
+DATE_AFTER_AIP_2 = "2020-06-02"
+DATE_BEFORE_AIP_3 = "2021-05-30"
+DATE_AFTER_AIP_3 = "2021-06-01"
+
+
+TEST_AIP_1_EXPECTED = {
+    "AIPName": "TestAIP1",
+    "CreatedDate": "2020-01-01 00:00:00",
+    "Formats": {
+        "fmt/43": {"Count": 1, "Name": "JPEG", "Version": "1.01"},
+        "fmt/test-1": {"Count": 1, "Name": "txt", "Version": "0.0.0"},
+    },
+    "Size": 300,
+    "UUID": "111111111111-1111-1111-11111111",
+}
+
+TEST_AIP_2_EXPECTED = {
+    "AIPName": "TestAIP2",
+    "CreatedDate": "2020-06-01 00:00:00",
+    "Formats": {"fmt/44": {"Count": 1, "Name": "JPEG", "Version": "1.02"}},
+    "Size": 1000,
+    "UUID": "222222222222-2222-2222-22222222",
+}
+
+TEST_AIP_3_EXPECTED = {
+    "AIPName": "TestAIP3",
+    "CreatedDate": "2021-05-31 00:00:00",
+    "Formats": {
+        "fmt/test-1": {"Count": 2, "Name": "ACME File Format", "Version": "0.0.0"}
+    },
+    "Size": 2500,
+    "UUID": "333333333333-3333-3333-33333333",
+}
+
+
+@pytest.mark.parametrize(
+    "storage_service_id, storage_service_name, storage_location_id, storage_location_description, start_date, end_date, expected_aips_count, expected_first_aip",
+    [
+        # Request for a Storage Service populated with two locations, each
+        # containing AIPs and files.
+        (
+            1,
+            "test storage service",
+            None,
+            None,
+            DATE_BEFORE_AIP_1,
+            DATE_AFTER_AIP_3,
+            3,
+            TEST_AIP_1_EXPECTED,
+        ),
+        # Request for a non-existent Storage Service.
+        (4, None, None, None, DATE_BEFORE_AIP_1, DATE_BEFORE_AIP_3, 0, None),
+        # Request for a None Storage Service.
+        (None, None, None, None, DATE_BEFORE_AIP_1, DATE_BEFORE_AIP_3, 0, None),
+        # Request with valid Storage Location.
+        (
+            1,
+            "test storage service",
+            1,
+            STORAGE_LOCATION_1_DESCRIPTION,
+            DATE_BEFORE_AIP_1,
+            DATE_AFTER_AIP_3,
+            2,
+            TEST_AIP_1_EXPECTED,
+        ),
+        (
+            1,
+            "test storage service",
+            2,
+            STORAGE_LOCATION_2_DESCRIPTION,
+            DATE_BEFORE_AIP_1,
+            DATE_AFTER_AIP_3,
+            1,
+            TEST_AIP_3_EXPECTED,
+        ),
+        # Request for a non-existent Storage Location.
+        (
+            1,
+            "test storage service",
+            4,
+            None,
+            DATE_BEFORE_AIP_1,
+            DATE_BEFORE_AIP_3,
+            0,
+            None,
+        ),
+        # Test date filtering.
+        (
+            1,
+            "test storage service",
+            None,
+            None,
+            DATE_AFTER_AIP_1,
+            DATE_AFTER_AIP_2,
+            1,
+            TEST_AIP_2_EXPECTED,
+        ),
+        (
+            1,
+            "test storage service",
+            None,
+            None,
+            DATE_BEFORE_AIP_1,
+            DATE_BEFORE_AIP_2,
+            1,
+            TEST_AIP_1_EXPECTED,
+        ),
+        (
+            1,
+            "test storage service",
+            None,
+            None,
+            DATE_BEFORE_AIP_1,
+            DATE_BEFORE_AIP_3,
+            2,
+            TEST_AIP_1_EXPECTED,
+        ),
+        (
+            1,
+            "test storage service",
+            None,
+            None,
+            DATE_AFTER_AIP_2,
+            DATE_AFTER_AIP_3,
+            1,
+            TEST_AIP_3_EXPECTED,
+        ),
+    ],
+)
+def test_aip_contents_data(
+    storage_locations,
+    storage_service_id,
+    storage_service_name,
+    storage_location_id,
+    storage_location_description,
+    start_date,
+    end_date,
+    expected_aips_count,
+    expected_first_aip,
+):
+    """Test response from report_data.storage_locations endpoint."""
+    start_date = parse_datetime_bound(start_date)
+    end_date = parse_datetime_bound(end_date, upper=True)
+
+    report = data.aip_file_format_overview(
+        storage_service_id=storage_service_id,
+        start_date=start_date,
+        end_date=end_date,
+        storage_location_id=storage_location_id,
+    )
+
+    assert report[fields.FIELD_STORAGE_NAME] == storage_service_name
+    assert report[fields.FIELD_STORAGE_LOCATION] == storage_location_description
+
+    aips = report[fields.FIELD_AIPS]
+    aips_count = len(aips)
+    assert aips_count == expected_aips_count
+
+    if aips_count < 1:
+        return
+
+    assert aips[0] == expected_first_aip

--- a/AIPscan/Reporter/templates/report_aip_contents.html
+++ b/AIPscan/Reporter/templates/report_aip_contents.html
@@ -14,32 +14,39 @@
     <strong>Location:</strong> {{ storage_location_description }}
     <br>
   {% endif %}
-  <strong>AIPS:</strong> {{ rows|length }}
+  <strong>Start date:</strong> {{ start_date.strftime('%Y-%m-%d') }}
+  <br>
+  <strong>End date:</strong> {{ end_date.strftime('%Y-%m-%d') }}
+  <br>
+  <strong>AIPs:</strong> {{ aips|length }}
 </div>
 
-<table id="aips-1" class="table table-striped table-bordered">
-	<thead>
-    {% if rows %}
+{% if aips %}
+  <table id="aip-contents" class="table table-striped table-bordered">
+  	<thead>
     	<tr>
-      {% for column in columns %}
-      	{% if column.strip() == "UUID" %}
-		<th  width="300px">{{ column }}</th>
-		{% else %}
-		<th width="100px" title="{{ format_lookup.get(column, column) }}"><strong>{{ column }}</strong></th>
-		{% endif %}
-      {% endfor %}
+        {% for column in columns %}
+  		      <th>{{ column }}</th>
+        {% endfor %}
       </tr>
-      <tbody>
-      {% for row in rows %}
+    </thead>
+    <tbody>
+      {% for aip in aips %}
       	<tr>
-      	{% for cell in row %}
-      		<td>{{ cell }}</td>
-      	{% endfor %}
+          <td>
+            {{ aip["AIPName"] }}
+            <br>
+            <span class="small text-muted">UUID: {{ aip["UUID"] }}</span>
+          </td>
+          <td>{{ aip["CreatedDate"] }}</td>
+          <td>{{ aip["Size"] | filesizeformat }}</td>
+          <td>{{ aip["Formats"] | safe }}</td>
       	</tr>
       {% endfor %}
-    {% endif %}
     <tbody>
-  <thead>
-</table>
+  </table>
+{% else %}
+  <p class="h4" style="margin-top:20px;">No AIPs to display.</p>
+{% endif %}
 
 {% endblock %}

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -70,9 +70,13 @@
       </tr>
 
       <tr>
-          <td>AIP contents</td>
-          <td></td>
-          <td><a href="#"><button type="button" id="report2a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+          <td>
+            AIP contents
+            <br>
+            <span class="text-muted">Condensed overview of AIPs, including sorted list of file format versions by PUID.</span>
+          </td>
+          <td>Uses date fields</td>
+          <td><a href="#"><button type="button" id="aipContents" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
       </tr>
 
       <tr>
@@ -327,16 +331,26 @@ $(document).ready(function() {
         window.open(url);
     }
   });
-  $("#report2a").on("click", function() {
-    var url = (
-      window.location.origin +
-      '/reporter/aip_contents/' +
-      '?amss_id=' +
-      storageServiceId +
-      '&storage_location=' +
-      storageLocationId
-    );
-    window.open(url);
+  $("#aipContents").on("click", function() {
+    var startdate = $('#startdate').val();
+    var enddate = $('#enddate').val();
+    if (enddate < startdate) {
+        alert(DATE_ALERT_START);
+    } else {
+      var url = (
+        window.location.origin +
+        '/reporter/aip_contents/' +
+        '?amss_id=' +
+        storageServiceId +
+        '&storage_location=' +
+        storageLocationId +
+        '&start_date=' +
+        startdate +
+        '&end_date=' +
+        enddate
+      );
+      window.open(url);
+    }
   });
   $("#report3a").on("click", function() {
     var startdate = $('#startdate').val();

--- a/AIPscan/Reporter/tests/test_aip_contents.py
+++ b/AIPscan/Reporter/tests/test_aip_contents.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-EXPECTED_CSV_CONTENTS = b"UUID,AIP Name,Created Date,AIP Size,fmt/43,fmt/61,x-fmt/111\r\n111111111111-1111-1111-11111111,Test AIP,2020-01-01 00:00:00,0 Bytes,1,1,0\r\n222222222222-2222-2222-22222222,Test AIP,2020-06-01 00:00:00,0 Bytes,0,2,3\r\n"
+EXPECTED_CSV_CONTENTS = b"UUID,AIP Name,Created Date,Size,Formats\r\n111111111111-1111-1111-11111111,Test AIP,2020-01-01 00:00:00,0 Bytes,fmt/43 (ACME File Format 0.0.0): 1 file|fmt/61 (ACME File Format 0.0.0): 1 file\r\n222222222222-2222-2222-22222222,Test AIP,2020-06-01 00:00:00,0 Bytes,x-fmt/111 (ACME File Format 0.0.0): 3 files|fmt/61 (ACME File Format 0.0.0): 2 files\r\n"
 
 
 def test_aip_contents(aip_contents):

--- a/AIPscan/conftest.py
+++ b/AIPscan/conftest.py
@@ -30,9 +30,11 @@ AIP_3_CREATION_DATE = "2021-05-31"
 
 AIP_1_NAME = "TestAIP1"
 AIP_2_NAME = "TestAIP2"
+AIP_3_NAME = "TestAIP3"
 
 AIP_1_UUID = "111111111111-1111-1111-11111111"
 AIP_2_UUID = "222222222222-2222-2222-22222222"
+AIP_3_UUID = "333333333333-3333-3333-33333333"
 
 ORIGINAL_FILE_1_NAME = "original-file-1.jpg"
 ORIGINAL_FILE_1_UUID = "333333333333-3333-3333-33333333"
@@ -463,6 +465,8 @@ def storage_locations(scope="package"):
 
         # Create one AIP associated with Storage Location 2.
         aip3 = test_helpers.create_test_aip(
+            uuid=AIP_3_UUID,
+            transfer_name=AIP_3_NAME,
             create_date=datetime.strptime(AIP_3_CREATION_DATE, AIP_DATE_FORMAT),
             storage_service_id=storage_service.id,
             storage_location_id=storage_location2.id,


### PR DESCRIPTION
Connected to #152

Reworked print-friendly report (dropping the Datatable, so that all results are printable) in UI:

![image](https://user-images.githubusercontent.com/6758804/121459577-897f9e00-c979-11eb-8345-72c1a2db14fc.png)

The CSV report uses a pipe (`|`) to separate the format strings, rather than a newline as in the web UI.