### PR TITLE
Cleanup Fetch Job downloads directory

### DIFF
--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -360,7 +360,7 @@ def collect_mets_agents(mets):
         if aip_file.use != ORIGINAL_OBJECT and aip_file.use != PRESERVATION_OBJECT:
             continue
         agents = agents + _get_unique_agents(aip_file.get_premis_agents(), agents)
-    logger.info("Total  agents: %d", len(agents))
+    logger.info("Total agents: %d", len(agents))
     return agents
 
 

--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -101,8 +101,14 @@ def parse_packages_and_load_mets(
     """
     OBJECTS = "objects"
     packages = []
-    with open(json_file_path, "r") as packagesJson:
-        package_list = json.load(packagesJson)
+    with open(json_file_path, "r") as packages_json:
+        package_list = json.load(packages_json)
+
+    try:
+        os.remove(json_file_path)
+    except OSError as err:
+        logger.warning("Unable to delete package JSON file: {}".format(err))
+
     for package_obj in package_list.get(OBJECTS, []):
         package = process_package_object(package_obj)
         packages.append(package)
@@ -336,3 +342,9 @@ def get_mets(
     )
 
     database_helpers.process_aip_data(aip, mets)
+
+    # Delete downloaded METS file.
+    try:
+        os.remove(download_file)
+    except OSError as err:
+        logger.warning("Unable to delete METS file: {}".format(err))


### PR DESCRIPTION
Connected to #161 

The `AIPscan/Aggregator/downloads/` directory was previously filling up during Fetch Jobs and causing disk space issues.

This PR modifies the `Aggregator` tasks to delete METS files and JSON package lists as soon as they are no longer needed.

Some empty directories are currently still left behind - e.g.:

```
AIPscan/Aggregator/downloads
└── 2021-06-30-12-14-35
    ├── mets
    │   ├── 1
    │   ├── 2
    │   ├── 3
    │   └── 4
    └── packages
```

Ideally we'd clean up these empty directories as well, but that will require larger changes to the asynchronous processing tasks. Until we can address that, it might be good to occasionally delete these empty directories through a cron job or similar.