### PR TITLE
Delete already-parsed METS files

### DIFF
--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -304,6 +304,10 @@ def get_mets(
         logger.info(
             "Skipping METS file {} - identical to existing record".format(mets_name)
         )
+        try:
+            os.remove(download_file)
+        except OSError as err:
+            logger.warning("Unable to delete METS file: {}".format(err))
         return
 
     logger.info("Processing METS file {}".format(mets_name))

--- a/AIPscan/Aggregator/tests/test_tasks.py
+++ b/AIPscan/Aggregator/tests/test_tasks.py
@@ -151,6 +151,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
         mocker.call(mets_file),
     ]
     delete_mets_file.assert_has_calls(delete_calls, any_order=True)
+    delete_mets_file.call_count == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Connected to #161 

This PR fixes an oversight whereby already-parsed METS files weren't being deleted after being downloaded.