### PR TITLE
Add Largest AIPs report

### DIFF
--- a/AIPscan/API/namespace_report_data.py
+++ b/AIPscan/API/namespace_report_data.py
@@ -108,6 +108,16 @@ class LargestFileList(Resource):
     @api.doc(
         "list_largest_files",
         params={
+            fields.FIELD_START_DATE: {
+                "description": "AIP creation start date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_END_DATE: {
+                "description": "AIP creation end date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
             fields.FIELD_FILE_TYPE: {
                 "description": "Optional file type filter (original or preservation)",
                 "in": "query",
@@ -127,6 +137,10 @@ class LargestFileList(Resource):
     )
     def get(self, storage_service_id, file_type=None, limit=20):
         """List largest files"""
+        start_date = parse_datetime_bound(request.args.get(fields.FIELD_START_DATE))
+        end_date = parse_datetime_bound(
+            request.args.get(fields.FIELD_END_DATE), upper=True
+        )
         file_type = request.args.get(fields.FIELD_FILE_TYPE)
         storage_location_id = request.args.get(fields.FIELD_STORAGE_LOCATION)
         try:
@@ -135,6 +149,8 @@ class LargestFileList(Resource):
             pass
         return report_data.largest_files(
             storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
             storage_location_id=storage_location_id,
             file_type=file_type,
             limit=limit,

--- a/AIPscan/API/namespace_report_data.py
+++ b/AIPscan/API/namespace_report_data.py
@@ -59,7 +59,7 @@ class FormatVersionList(Resource):
 @api.route("/largest-files/<storage_service_id>")
 class LargestFileList(Resource):
     @api.doc(
-        "list_formats",
+        "list_largest_files",
         params={
             fields.FIELD_FILE_TYPE: {
                 "description": "Optional file type filter (original or preservation)",
@@ -90,6 +90,37 @@ class LargestFileList(Resource):
             storage_service_id=storage_service_id,
             storage_location_id=storage_location_id,
             file_type=file_type,
+            limit=limit,
+        )
+
+
+@api.route("/largest-aips/<storage_service_id>")
+class LargestAIPList(Resource):
+    @api.doc(
+        "list_largest_aips",
+        params={
+            fields.FIELD_LIMIT: {
+                "description": "Number of results to return (default is 20)",
+                "in": "query",
+                "type": "int",
+            },
+            fields.FIELD_STORAGE_LOCATION: {
+                "description": "Storage Location ID",
+                "in": "query",
+                "type": "int",
+            },
+        },
+    )
+    def get(self, storage_service_id, limit=20):
+        """List largest AIPs"""
+        storage_location_id = request.args.get(fields.FIELD_STORAGE_LOCATION)
+        try:
+            limit = int(request.args.get(fields.FIELD_LIMIT, 20))
+        except ValueError:
+            pass
+        return report_data.largest_aips(
+            storage_service_id=storage_service_id,
+            storage_location_id=storage_location_id,
             limit=limit,
         )
 

--- a/AIPscan/API/namespace_report_data.py
+++ b/AIPscan/API/namespace_report_data.py
@@ -93,7 +93,7 @@ class LargestAIPList(Resource):
         try:
             limit = int(request.args.get(fields.FIELD_LIMIT, 20))
         except ValueError:
-            pass
+            limit = 20
         return report_data.largest_aips(
             storage_service_id=storage_service_id,
             start_date=start_date,
@@ -146,7 +146,7 @@ class LargestFileList(Resource):
         try:
             limit = int(request.args.get(fields.FIELD_LIMIT, 20))
         except ValueError:
-            pass
+            limit = 20
         return report_data.largest_files(
             storage_service_id=storage_service_id,
             start_date=start_date,

--- a/AIPscan/API/namespace_report_data.py
+++ b/AIPscan/API/namespace_report_data.py
@@ -56,6 +56,53 @@ class FormatVersionList(Resource):
         )
 
 
+@api.route("/largest-aips/<storage_service_id>")
+class LargestAIPList(Resource):
+    @api.doc(
+        "list_largest_aips",
+        params={
+            fields.FIELD_START_DATE: {
+                "description": "AIP creation start date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_END_DATE: {
+                "description": "AIP creation end date (inclusive, YYYY-MM-DD)",
+                "in": "query",
+                "type": "str",
+            },
+            fields.FIELD_LIMIT: {
+                "description": "Number of results to return (default is 20)",
+                "in": "query",
+                "type": "int",
+            },
+            fields.FIELD_STORAGE_LOCATION: {
+                "description": "Storage Location ID",
+                "in": "query",
+                "type": "int",
+            },
+        },
+    )
+    def get(self, storage_service_id, limit=20):
+        """List largest AIPs"""
+        start_date = parse_datetime_bound(request.args.get(fields.FIELD_START_DATE))
+        end_date = parse_datetime_bound(
+            request.args.get(fields.FIELD_END_DATE), upper=True
+        )
+        storage_location_id = request.args.get(fields.FIELD_STORAGE_LOCATION)
+        try:
+            limit = int(request.args.get(fields.FIELD_LIMIT, 20))
+        except ValueError:
+            pass
+        return report_data.largest_aips(
+            storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
+            storage_location_id=storage_location_id,
+            limit=limit,
+        )
+
+
 @api.route("/largest-files/<storage_service_id>")
 class LargestFileList(Resource):
     @api.doc(
@@ -90,37 +137,6 @@ class LargestFileList(Resource):
             storage_service_id=storage_service_id,
             storage_location_id=storage_location_id,
             file_type=file_type,
-            limit=limit,
-        )
-
-
-@api.route("/largest-aips/<storage_service_id>")
-class LargestAIPList(Resource):
-    @api.doc(
-        "list_largest_aips",
-        params={
-            fields.FIELD_LIMIT: {
-                "description": "Number of results to return (default is 20)",
-                "in": "query",
-                "type": "int",
-            },
-            fields.FIELD_STORAGE_LOCATION: {
-                "description": "Storage Location ID",
-                "in": "query",
-                "type": "int",
-            },
-        },
-    )
-    def get(self, storage_service_id, limit=20):
-        """List largest AIPs"""
-        storage_location_id = request.args.get(fields.FIELD_STORAGE_LOCATION)
-        try:
-            limit = int(request.args.get(fields.FIELD_LIMIT, 20))
-        except ValueError:
-            pass
-        return report_data.largest_aips(
-            storage_service_id=storage_service_id,
-            storage_location_id=storage_location_id,
             limit=limit,
         )
 

--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -154,10 +154,11 @@ def create_aip_object(
     transfer_name,
     create_date,
     mets_sha256,
-    storage_service_id,
-    storage_location_id,
-    fetch_job_id,
-    origin_pipeline_id,
+    size=0,
+    storage_service_id=1,
+    storage_location_id=1,
+    fetch_job_id=1,
+    origin_pipeline_id=1,
 ):
     """Create an AIP object and save it to the database."""
     aip = AIP(
@@ -165,6 +166,7 @@ def create_aip_object(
         transfer_name=transfer_name,
         create_date=_tz_neutral_date(create_date),
         mets_sha256=mets_sha256,
+        size=size,
         storage_service_id=storage_service_id,
         storage_location_id=storage_location_id,
         fetch_job_id=fetch_job_id,

--- a/AIPscan/Aggregator/task_helpers.py
+++ b/AIPscan/Aggregator/task_helpers.py
@@ -73,6 +73,7 @@ def process_package_object(package_obj):
     package.current_location = package_obj.get(CURRENT_LOCATION)
     package.current_path = package_obj.get(CURRENT_PATH)
     package.origin_pipeline = package_obj.get(ORIGIN_PIPELINE)
+    package.size = package_obj.get("size")
 
     return package
 

--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -47,6 +47,7 @@ def write_packages_json(count, packages, packages_directory):
 
 def start_mets_task(
     package_uuid,
+    aip_size,
     relative_path_to_mets,
     current_location,
     origin_pipeline,
@@ -68,6 +69,7 @@ def start_mets_task(
     # Call worker to download and parse METS File.
     get_mets_task = get_mets.delay(
         package_uuid,
+        aip_size,
         relative_path_to_mets,
         api_url,
         timestamp_str,
@@ -116,6 +118,7 @@ def parse_packages_and_load_mets(
             continue
         start_mets_task(
             package.uuid,
+            package.size,
             package.get_relative_path(),
             package.current_location,
             package.origin_pipeline,
@@ -272,6 +275,7 @@ def package_lists_request(self, apiUrl, timestamp, packages_directory):
 @celery.task()
 def get_mets(
     package_uuid,
+    aip_size,
     relative_path_to_mets,
     api_url,
     timestamp_str,
@@ -339,6 +343,7 @@ def get_mets(
         transfer_name=original_name,
         create_date=mets.createdate,
         mets_sha256=mets_hash,
+        size=aip_size,
         storage_service_id=storage_service_id,
         storage_location_id=storage_location_id,
         fetch_job_id=fetch_job_id,

--- a/AIPscan/Aggregator/tests/test_tasks.py
+++ b/AIPscan/Aggregator/tests/test_tasks.py
@@ -80,6 +80,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     )
     get_mets(
         package_uuid=package_uuid,
+        aip_size=1000,
         relative_path_to_mets="test",
         api_url=api_url,
         timestamp_str=datetime.now()
@@ -103,6 +104,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     )
     get_mets(
         package_uuid=package_uuid,
+        aip_size=1000,
         relative_path_to_mets="test",
         api_url=api_url,
         timestamp_str=datetime.now()
@@ -128,6 +130,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
     )
     get_mets(
         package_uuid=package_uuid,
+        aip_size=1000,
         relative_path_to_mets="test",
         api_url=api_url,
         timestamp_str=datetime.now()

--- a/AIPscan/Data/report_data.py
+++ b/AIPscan/Data/report_data.py
@@ -317,9 +317,10 @@ def largest_aips(storage_service_id, storage_location_id=None, limit=20):
     for aip in aips:
         aip_info = {}
 
-        aip_info[fields.FIELD_UUID] = aip.uuid
         aip_info[fields.FIELD_NAME] = aip.transfer_name
-        aip_info[fields.FIELD_AIP_SIZE] = aip.size
+        aip_info[fields.FIELD_UUID] = aip.uuid
+        aip_info[fields.FIELD_SIZE] = aip.size
+        aip_info[fields.FIELD_FILE_COUNT] = aip.original_file_count
 
         report[fields.FIELD_AIPS].append(aip_info)
 

--- a/AIPscan/Data/report_data.py
+++ b/AIPscan/Data/report_data.py
@@ -281,23 +281,32 @@ def largest_files(
     return report
 
 
-def _largest_aips_query(storage_service_id, storage_location_id, limit):
+def _largest_aips_query(
+    storage_service_id, start_date, end_date, storage_location_id, limit
+):
     """Fetch information from database for largest AIPs query."""
     aips = (
-        # TODO: Make this query actually work!
         AIP.query.join(StorageLocation)
         .join(StorageService)
         .filter(StorageService.id == storage_service_id)
+        .filter(AIP.create_date >= start_date)
+        .filter(AIP.create_date < end_date)
     )
     if storage_location_id:
         aips = aips.filter(StorageLocation.id == storage_location_id)
     return aips.order_by(AIP.size.desc()).limit(limit)
 
 
-def largest_aips(storage_service_id, storage_location_id=None, limit=20):
+def largest_aips(
+    storage_service_id, start_date, end_date, storage_location_id=None, limit=20
+):
     """Return a summary of the largest AIPs in a given Storage Service
 
     :param storage_service_id: Storage Service ID
+    :param start_date: Inclusive AIP creation start date
+        (datetime.datetime object)
+    :param end_date: Inclusive AIP creation end date
+        (datetime.datetime object)
     :param storage_location_id: Storage Location ID (int)
     :param limit: Upper limit of number of results to return
 
@@ -312,7 +321,9 @@ def largest_aips(storage_service_id, storage_location_id=None, limit=20):
         storage_location_id
     )
 
-    aips = _largest_aips_query(storage_service_id, storage_location_id, limit)
+    aips = _largest_aips_query(
+        storage_service_id, start_date, end_date, storage_location_id, limit
+    )
 
     for aip in aips:
         aip_info = {}

--- a/AIPscan/Data/tests/__init__.py
+++ b/AIPscan/Data/tests/__init__.py
@@ -67,6 +67,7 @@ MOCK_AIP = AIP(
     transfer_name=MOCK_AIP_NAME,
     create_date=datetime.datetime.now(),
     mets_sha256="test",
+    size=0,
     storage_service_id=MOCK_STORAGE_SERVICE_ID,
     storage_location_id=MOCK_STORAGE_LOCATION_ID,
     fetch_job_id=1,

--- a/AIPscan/Data/tests/test_largest_aips.py
+++ b/AIPscan/Data/tests/test_largest_aips.py
@@ -28,5 +28,5 @@ def test_largest_aips(
     assert report[fields.FIELD_STORAGE_LOCATION] == storage_location_description
 
     assert len(report_aips) == aip_count
-    assert report_aips[0][fields.FIELD_AIP_SIZE] == largest_aip_size
-    assert report_aips[1][fields.FIELD_AIP_SIZE] == second_largest_aip_size
+    assert report_aips[0][fields.FIELD_SIZE] == largest_aip_size
+    assert report_aips[1][fields.FIELD_SIZE] == second_largest_aip_size

--- a/AIPscan/Data/tests/test_largest_aips.py
+++ b/AIPscan/Data/tests/test_largest_aips.py
@@ -1,27 +1,37 @@
 import pytest
 
 from AIPscan.Data import fields, report_data
+from AIPscan.helpers import parse_datetime_bound
 
 
 @pytest.mark.parametrize(
-    "storage_location_id, storage_location_description, aip_count,largest_aip_size,second_largest_aip_size",
+    "storage_location_id, storage_location_description, start_date, end_date, aip_count,largest_aip_size,second_largest_aip_size",
     [
-        (None, None, 5, 10000, 750),
-        (1, "storage location 1", 2, 10000, 250),
-        (2, "storage location 2", 3, 750, 500),
+        # Test all AIPs.
+        (None, None, "2020-01-01", "2022-12-31", 5, 10000, 750),
+        # Test filtering by date.
+        (None, None, "2020-01-01", "2020-06-01", 2, 10000, 250),
+        # Test filtering by storage location.
+        (1, "storage location 1", "2020-01-01", "2022-12-31", 2, 10000, 250),
+        (2, "storage location 2", "2020-01-01", "2022-12-31", 3, 750, 500),
     ],
 )
 def test_largest_aips(
     largest_aips,
     storage_location_id,
     storage_location_description,
+    start_date,
+    end_date,
     aip_count,
     largest_aip_size,
     second_largest_aip_size,
 ):
     """Test that outputs of report_data.largest_aips match expectations."""
     report = report_data.largest_aips(
-        storage_service_id=1, storage_location_id=storage_location_id
+        storage_service_id=1,
+        start_date=parse_datetime_bound(start_date),
+        end_date=parse_datetime_bound(end_date, upper=True),
+        storage_location_id=storage_location_id,
     )
     report_aips = report[fields.FIELD_AIPS]
     assert report[fields.FIELD_STORAGE_NAME] == "test storage service"

--- a/AIPscan/Data/tests/test_largest_aips.py
+++ b/AIPscan/Data/tests/test_largest_aips.py
@@ -1,0 +1,32 @@
+import pytest
+
+from AIPscan.Data import fields, report_data
+
+
+@pytest.mark.parametrize(
+    "storage_location_id, storage_location_description, aip_count,largest_aip_size,second_largest_aip_size",
+    [
+        (None, None, 5, 10000, 750),
+        (1, "storage location 1", 2, 10000, 250),
+        (2, "storage location 2", 3, 750, 500),
+    ],
+)
+def test_largest_aips(
+    largest_aips,
+    storage_location_id,
+    storage_location_description,
+    aip_count,
+    largest_aip_size,
+    second_largest_aip_size,
+):
+    """Test that outputs of report_data.largest_aips match expectations."""
+    report = report_data.largest_aips(
+        storage_service_id=1, storage_location_id=storage_location_id
+    )
+    report_aips = report[fields.FIELD_AIPS]
+    assert report[fields.FIELD_STORAGE_NAME] == "test storage service"
+    assert report[fields.FIELD_STORAGE_LOCATION] == storage_location_description
+
+    assert len(report_aips) == aip_count
+    assert report_aips[0][fields.FIELD_AIP_SIZE] == largest_aip_size
+    assert report_aips[1][fields.FIELD_AIP_SIZE] == second_largest_aip_size

--- a/AIPscan/Reporter/report_largest_aips.py
+++ b/AIPscan/Reporter/report_largest_aips.py
@@ -1,10 +1,11 @@
 from flask import render_template, request
 
 from AIPscan.Data import fields, report_data
-from AIPscan.helpers import parse_bool
+from AIPscan.helpers import parse_bool, parse_datetime_bound
 from AIPscan.Reporter import (
     download_csv,
     format_size_for_csv,
+    get_display_end_date,
     reporter,
     request_params,
     translate_headers,
@@ -22,6 +23,10 @@ HEADERS = [
 def largest_aips():
     """Return largest files."""
     storage_service_id = request.args.get(request_params.STORAGE_SERVICE_ID)
+    start_date = parse_datetime_bound(request.args.get(request_params.START_DATE))
+    end_date = parse_datetime_bound(
+        request.args.get(request_params.END_DATE), upper=True
+    )
     storage_location_id = request.args.get(request_params.STORAGE_LOCATION_ID)
     limit = 20
     try:
@@ -34,6 +39,8 @@ def largest_aips():
 
     aip_data = report_data.largest_aips(
         storage_service_id=storage_service_id,
+        start_date=start_date,
+        end_date=end_date,
         storage_location_id=storage_location_id,
         limit=limit,
     )
@@ -53,4 +60,6 @@ def largest_aips():
         columns=headers,
         aips=aip_data[fields.FIELD_AIPS],
         limit=limit,
+        start_date=start_date,
+        end_date=get_display_end_date(end_date),
     )

--- a/AIPscan/Reporter/report_largest_aips.py
+++ b/AIPscan/Reporter/report_largest_aips.py
@@ -1,0 +1,56 @@
+from flask import render_template, request
+
+from AIPscan.Data import fields, report_data
+from AIPscan.helpers import parse_bool
+from AIPscan.Reporter import (
+    download_csv,
+    format_size_for_csv,
+    reporter,
+    request_params,
+    translate_headers,
+)
+
+HEADERS = [
+    fields.FIELD_AIP_NAME,
+    fields.FIELD_UUID,
+    fields.FIELD_AIP_SIZE,
+    fields.FIELD_FILE_COUNT,
+]
+
+
+@reporter.route("/largest_aips/", methods=["GET"])
+def largest_aips():
+    """Return largest files."""
+    storage_service_id = request.args.get(request_params.STORAGE_SERVICE_ID)
+    storage_location_id = request.args.get(request_params.STORAGE_LOCATION_ID)
+    limit = 20
+    try:
+        limit = int(request.args.get(request_params.LIMIT, 20))
+    except ValueError:
+        pass
+    csv = parse_bool(request.args.get(request_params.CSV), default=False)
+
+    headers = translate_headers(HEADERS)
+
+    aip_data = report_data.largest_aips(
+        storage_service_id=storage_service_id,
+        storage_location_id=storage_location_id,
+        limit=limit,
+    )
+
+    if csv:
+        filename = "largest_aips.csv"
+        headers = translate_headers(HEADERS)
+        csv_data = format_size_for_csv(aip_data[fields.FIELD_AIPS])
+        return download_csv(headers, csv_data, filename)
+
+    return render_template(
+        "report_largest_aips.html",
+        storage_service_id=storage_service_id,
+        storage_service_name=aip_data.get(fields.FIELD_STORAGE_NAME),
+        storage_location_id=storage_location_id,
+        storage_location_description=aip_data.get(fields.FIELD_STORAGE_LOCATION),
+        columns=headers,
+        aips=aip_data[fields.FIELD_AIPS],
+        limit=limit,
+    )

--- a/AIPscan/Reporter/report_largest_files.py
+++ b/AIPscan/Reporter/report_largest_files.py
@@ -3,10 +3,11 @@
 from flask import render_template, request
 
 from AIPscan.Data import fields, report_data
-from AIPscan.helpers import parse_bool
+from AIPscan.helpers import parse_bool, parse_datetime_bound
 from AIPscan.Reporter import (
     download_csv,
     format_size_for_csv,
+    get_display_end_date,
     reporter,
     request_params,
     translate_headers,
@@ -38,6 +39,10 @@ CSV_HEADERS = [
 def largest_files():
     """Return largest files."""
     storage_service_id = request.args.get(request_params.STORAGE_SERVICE_ID)
+    start_date = parse_datetime_bound(request.args.get(request_params.START_DATE))
+    end_date = parse_datetime_bound(
+        request.args.get(request_params.END_DATE), upper=True
+    )
     storage_location_id = request.args.get(request_params.STORAGE_LOCATION_ID)
     file_type = request.args.get(request_params.FILE_TYPE)
     limit = 20
@@ -51,6 +56,8 @@ def largest_files():
 
     file_data = report_data.largest_files(
         storage_service_id=storage_service_id,
+        start_date=start_date,
+        end_date=end_date,
         storage_location_id=storage_location_id,
         file_type=file_type,
         limit=limit,
@@ -72,4 +79,6 @@ def largest_files():
         files=file_data[fields.FIELD_FILES],
         file_type=file_type,
         limit=limit,
+        start_date=start_date,
+        end_date=get_display_end_date(end_date),
     )

--- a/AIPscan/Reporter/templates/report_largest_aips.html
+++ b/AIPscan/Reporter/templates/report_largest_aips.html
@@ -14,6 +14,10 @@
     <strong>Location:</strong> {{ storage_location_description }}
     <br>
   {% endif %}
+  <strong>Start date:</strong> {{ start_date.strftime('%Y-%m-%d') }}
+  <br>
+  <strong>End date:</strong> {{ end_date.strftime('%Y-%m-%d') }}
+  <br>
 
 </div>
 

--- a/AIPscan/Reporter/templates/report_largest_aips.html
+++ b/AIPscan/Reporter/templates/report_largest_aips.html
@@ -1,0 +1,45 @@
+{% extends "report_base.html" %}
+
+{% block content %}
+
+<div class="alert alert-secondary">
+
+  {% include "report_buttons.html" %}
+
+  <strong>Report: Largest AIPs</strong>
+  <br>
+  <strong>Storage Service:</strong> {{ storage_service_name }}
+  <br>
+  {% if storage_location_description %}
+    <strong>Location:</strong> {{ storage_location_description }}
+    <br>
+  {% endif %}
+
+</div>
+
+{% if aips %}
+  <table id="largest-aips" class="table table-striped table-bordered">
+  	<thead>
+      <tr>
+      {% for column in columns %}
+        <th>{{ column }}</th>
+      {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for aip in aips %}
+        <tr> 
+          <td>{{ aip["Name"] }}</td>
+          <td>{{ aip["UUID"] }}</td>
+          <td>{{ aip["Size"] | filesizeformat }}</td>
+          <td>{{ aip["FileCount"] }}
+      {% endfor %}
+    </tbody>
+  </table>
+{% else %}
+  <p class="h4" style="margin-top:20px;">No AIPs to display.</p>
+{% endif %}
+
+</div>
+
+{% endblock %}

--- a/AIPscan/Reporter/templates/report_largest_files.html
+++ b/AIPscan/Reporter/templates/report_largest_files.html
@@ -21,10 +21,17 @@
   {% else %}
     <strong>File type:</strong> All files
   {% endif %}
+  <br>
+  <strong>Start date:</strong> {{ start_date.strftime('%Y-%m-%d') }}
+  <br>
+  <strong>End date:</strong> {{ end_date.strftime('%Y-%m-%d') }}
+  <br>
 
   <!-- Hidden elements we want available from JS for URL generation -->
   <span id="storageServiceID" style="display:none;">{{ storage_service_id }}</span>
   <span id="storageLocationID" style="display:none;">{{ storage_location_id }}</span>
+  <span id="startDate" style="display:none;">{{ start_date.strftime('%Y-%m-%d') }}</span>
+  <span id="endDate" style="display:none;">{{ end_date.strftime('%Y-%m-%d') }}</span>
   <span id="limit" style="display:none;">{{ limit }}</span>
 </div>
 

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -417,7 +417,8 @@ $(document).ready(function() {
         '&end_date=' +
         enddate +
         '&storage_location=' +
-        storageLocationId
+        storageLocationId +
+        '&limit=20'
       );
       window.open(url);
     }
@@ -438,7 +439,8 @@ $(document).ready(function() {
         '&end_date=' +
         enddate +
         '&storage_location=' +
-        storageLocationId
+        storageLocationId +
+        '&limit=20'
       );
       window.open(url);
     }

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -83,7 +83,7 @@
       <tr>
           <td><strong>Largest AIPs</strong></td>
           <td><span class="text-muted">Top twenty largest AIPs in the Storage Service.
-            <br>Filter by storage location.</span></td>
+            <br>Filter by date range and storage location.</span></td>
           <td><a href="#"><button type="button" id="largestAIPs" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
       </tr>
 
@@ -402,15 +402,25 @@ $(document).ready(function() {
     window.open(url);
   });
   $("#largestAIPs").on("click", function() {
-    var url = (
-      window.location.origin +
-      '/reporter/largest_aips/' +
-      '?amss_id=' +
-      storageServiceId +
-      '&storage_location=' +
-      storageLocationId
-    );
-    window.open(url);
+    var startdate = $('#startdate').val();
+    var enddate = $('#enddate').val();
+    if (enddate < startdate) {
+      alert(DATE_ALERT_START);
+    } else {
+      var url = (
+        window.location.origin +
+        '/reporter/largest_aips/' +
+        '?amss_id=' +
+        storageServiceId +
+        '&start_date=' +
+        startdate +
+        '&end_date=' +
+        enddate +
+        '&storage_location=' +
+        storageLocationId
+      );
+      window.open(url);
+    }
   });
   $("#largestFiles").on("click", function() {
     var url = (

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -81,11 +81,18 @@
       </tr>
 
       <tr>
+          <td><strong>Largest AIPs</strong></td>
+          <td><span class="text-muted">Top twenty largest AIPs in the Storage Service.
+            <br>Filter by storage location.</span></td>
+          <td><a href="#"><button type="button" id="largestAIPs" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+      </tr>
+
+      <tr>
           <td><strong>Largest files</strong></td>
           <td><span class="text-muted">Top twenty largest files in the Storage Service.
             <br>Filter by storage location.
             <br>Filter by originals or preservation copies (in report).</span></td>
-          <td><a href="#"><button type="button" id="report9a" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
+          <td><a href="#"><button type="button" id="largestFiles" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
       </tr>
 
       <tr>
@@ -394,7 +401,18 @@ $(document).ready(function() {
     );
     window.open(url);
   });
-  $("#report9a").on("click", function() {
+  $("#largestAIPs").on("click", function() {
+    var url = (
+      window.location.origin +
+      '/reporter/largest_aips/' +
+      '?amss_id=' +
+      storageServiceId +
+      '&storage_location=' +
+      storageLocationId
+    );
+    window.open(url);
+  });
+  $("#largestFiles").on("click", function() {
     var url = (
       window.location.origin +
       '/reporter/largest_files/' +

--- a/AIPscan/Reporter/templates/reports.html
+++ b/AIPscan/Reporter/templates/reports.html
@@ -90,7 +90,7 @@
       <tr>
           <td><strong>Largest files</strong></td>
           <td><span class="text-muted">Top twenty largest files in the Storage Service.
-            <br>Filter by storage location.
+            <br>Filter by date range and storage location.
             <br>Filter by originals or preservation copies (in report).</span></td>
           <td><a href="#"><button type="button" id="largestFiles" class="btn btn-info" style="margin-left:5px; margin-bottom:5px;">Tabular</button></a></td>
       </tr>
@@ -423,15 +423,25 @@ $(document).ready(function() {
     }
   });
   $("#largestFiles").on("click", function() {
-    var url = (
-      window.location.origin +
-      '/reporter/largest_files/' +
-      '?amss_id=' +
-      storageServiceId +
-      '&storage_location=' +
-      storageLocationId
-    );
-    window.open(url);
+    var startdate = $('#startdate').val();
+    var enddate = $('#enddate').val();
+    if (enddate < startdate) {
+      alert(DATE_ALERT_START);
+    } else {
+      var url = (
+        window.location.origin +
+        '/reporter/largest_files/' +
+        '?amss_id=' +
+        storageServiceId +
+        '&start_date=' +
+        startdate +
+        '&end_date=' +
+        enddate +
+        '&storage_location=' +
+        storageLocationId
+      );
+      window.open(url);
+    }
   });
   $("#aipsByOriginalFormat").on("click", function() {
     var fileFormat = $('#originalFormatSelect').val();

--- a/AIPscan/Reporter/tests/test_largest_aips.py
+++ b/AIPscan/Reporter/tests/test_largest_aips.py
@@ -1,0 +1,23 @@
+from flask import current_app
+
+EXPECTED_CSV_CONTENTS = b"AIP Name,UUID,AIP Size,File Count\r\nTest AIP,111111111111-1111-1111-11111111,100 Bytes,1\r\nTest AIP,222222222222-2222-2222-22222222,100 Bytes,2\r\n"
+
+
+def test_largest_aips(app_with_populated_format_versions):
+    """Test that report template renders."""
+    with current_app.test_client() as test_client:
+        response = test_client.get("/reporter/largest_aips/?amss_id=1")
+        assert response.status_code == 200
+
+
+def test_largest_aips_csv(app_with_populated_format_versions):
+    """Test CSV export."""
+    with current_app.test_client() as test_client:
+        response = test_client.get("/reporter/largest_aips/?amss_id=1&csv=True")
+        assert response.status_code == 200
+        assert (
+            response.headers["Content-Disposition"]
+            == "attachment; filename=largest_aips.csv"
+        )
+        assert response.mimetype == "text/csv"
+        assert response.data == EXPECTED_CSV_CONTENTS

--- a/AIPscan/Reporter/views.py
+++ b/AIPscan/Reporter/views.py
@@ -29,6 +29,7 @@ from AIPscan.Reporter import (  # noqa: F401
     report_format_versions_count,
     report_formats_count,
     report_ingest_log,
+    report_largest_aips,
     report_largest_files,
     report_preservation_derivatives,
     report_storage_locations,

--- a/AIPscan/conftest.py
+++ b/AIPscan/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 """This module defines shared AIPscan pytest fixtures."""
+import uuid
 from datetime import datetime
 
 import pytest
@@ -414,6 +415,83 @@ def aip_contents(scope="package"):
         _ = test_helpers.create_test_file(puid=PUID_3, aip_id=aip2.id)
         _ = test_helpers.create_test_file(puid=PUID_3, aip_id=aip2.id)
         _ = test_helpers.create_test_file(puid=PUID_3, aip_id=aip2.id)
+
+        yield app
+
+        db.drop_all()
+
+
+@pytest.fixture
+def largest_aips(scope="package"):
+    """Fixture with pre-populated data.
+
+    This fixture is used to create expected state which is then used to
+    test the Data.report_data.largest_aips endpoint.
+    """
+    app = create_app("test")
+    with app.app_context():
+        db.create_all()
+
+        storage_service = test_helpers.create_test_storage_service()
+        storage_location_1 = test_helpers.create_test_storage_location(
+            storage_service_id=storage_service.id, description="storage location 1"
+        )
+        storage_location_2 = test_helpers.create_test_storage_location(
+            storage_service_id=storage_service.id,
+            description="storage location 2",
+            current_location="/api/v2/location/test-location-2/",
+        )
+        _ = test_helpers.create_test_pipeline(storage_service_id=storage_service.id)
+        fetch_job = test_helpers.create_test_fetch_job(
+            storage_service_id=storage_service.id
+        )
+
+        # Create two AIPs in first storage location.
+        test_helpers.create_test_aip(
+            uuid=AIP_1_UUID,
+            create_date=datetime.strptime(AIP_1_CREATION_DATE, AIP_DATE_FORMAT),
+            size=10000,
+            storage_service_id=storage_service.id,
+            storage_location_id=storage_location_1.id,
+            fetch_job_id=fetch_job.id,
+        )
+
+        test_helpers.create_test_aip(
+            uuid=AIP_2_UUID,
+            create_date=datetime.strptime(AIP_2_CREATION_DATE, AIP_DATE_FORMAT),
+            size=250,
+            storage_service_id=storage_service.id,
+            storage_location_id=storage_location_1.id,
+            fetch_job_id=fetch_job.id,
+        )
+
+        # Create three AIPS in second storage location.
+        test_helpers.create_test_aip(
+            uuid=AIP_3_UUID,
+            create_date=datetime.strptime(AIP_3_CREATION_DATE, AIP_DATE_FORMAT),
+            size=500,
+            storage_service_id=storage_service.id,
+            storage_location_id=storage_location_2.id,
+            fetch_job_id=fetch_job.id,
+        )
+
+        test_helpers.create_test_aip(
+            uuid=str(uuid.uuid4()),
+            create_date=datetime.strptime(AIP_3_CREATION_DATE, AIP_DATE_FORMAT),
+            size=25,
+            storage_service_id=storage_service.id,
+            storage_location_id=storage_location_2.id,
+            fetch_job_id=fetch_job.id,
+        )
+
+        test_helpers.create_test_aip(
+            uuid=str(uuid.uuid4()),
+            create_date=datetime.strptime(AIP_3_CREATION_DATE, AIP_DATE_FORMAT),
+            size=750,
+            storage_service_id=storage_service.id,
+            storage_location_id=storage_location_2.id,
+            fetch_job_id=fetch_job.id,
+        )
 
         yield app
 

--- a/AIPscan/models.py
+++ b/AIPscan/models.py
@@ -311,6 +311,7 @@ class AIP(db.Model):
     transfer_name = db.Column(db.String(255))
     create_date = db.Column(db.DateTime())
     mets_sha256 = db.Column(db.String(64))
+    size = db.Column(db.Integer())
     storage_service_id = db.Column(
         db.Integer(), db.ForeignKey("storage_service.id"), nullable=False
     )
@@ -331,6 +332,7 @@ class AIP(db.Model):
         transfer_name,
         create_date,
         mets_sha256,
+        size,
         storage_service_id,
         storage_location_id,
         fetch_job_id,
@@ -340,6 +342,7 @@ class AIP(db.Model):
         self.transfer_name = transfer_name
         self.create_date = create_date
         self.mets_sha256 = mets_sha256
+        self.size = size
         self.storage_service_id = storage_service_id
         self.storage_location_id = storage_location_id
         self.fetch_job_id = fetch_job_id

--- a/AIPscan/static/js/report.js
+++ b/AIPscan/static/js/report.js
@@ -10,12 +10,18 @@ $(document).ready(function() {
     var fileType = $('#fileTypeSelector').val();
     var storageServiceId = $('#storageServiceID').text();
     var storageLocationId = $('#storageLocationID').text();
+    var startDate = $('#startDate').text();
+    var endDate = $('#endDate').text();
     var limit = $('#limit').text();
     var url = (
       window.location.origin +
       '/reporter/largest_files?' +
       'amss_id=' +
       storageServiceId +
+      '&start_date=' +
+      startDate +
+      '&end_date=' +
+      endDate +
       '&storage_location=' +
       storageLocationId +
       '&file_type=' +

--- a/AIPscan/test_helpers.py
+++ b/AIPscan/test_helpers.py
@@ -84,6 +84,7 @@ def create_test_aip(**kwargs):
         transfer_name=kwargs.get("transfer_name", "Test AIP"),
         create_date=kwargs.get("create_date", datetime.now()),
         mets_sha256=kwargs.get("mets_sha256", TEST_SHA_256),
+        size=kwargs.get("size", 100),
         storage_service_id=kwargs.get("storage_service_id", 1),
         storage_location_id=kwargs.get("storage_location_id", 1),
         fetch_job_id=kwargs.get("fetch_job_id", 1),


### PR DESCRIPTION
Connected to #174

This PR adds a new Largest AIPs report to AIPscan, similar to the existing Largest files report.

![image](https://user-images.githubusercontent.com/6758804/166400336-b7162087-9093-4a64-9233-bd580b650406.png)

Note: This PR includes a new `size` field on the `AIP` database model, which is a breaking change. Since we don't yet have database migrations in AIPscan, it is necessary to delete the existing `aipscan.db` SQLite database. When the application is restarted, a new database with the updated `AIP` model will be automatically created, and it will be necessary to run new Fetch Jobs to populate the database.

This PR also adds the date range parameters to the Largest files report, to make the user experience of these sibling reports consistent.