### PR TITLE
WIP: Add PREMIS Object XML to file model and template to make characterization tool output visible

### DIFF
--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -306,6 +306,18 @@ def _add_normalization_date(file_id):
         db.session.commit()
 
 
+def _add_characteristics_extension(fs_entry, file_id):
+    """Add string representation of PREMIS Object characteristics_extension to File object."""
+    file_ = File.query.get(file_id)
+    for premis_object in fs_entry.get_premis_objects():
+        if premis_object.characteristics_extension:
+            file_.characteristics_extension = str(
+                premis_object.characteristics_extension
+            )
+            db.session.commit()
+            return
+
+
 def _get_original_file(related_uuid):
     """Get original file related to preservation derivative."""
     return File.query.filter_by(uuid=related_uuid, file_type=FileType.original).first()
@@ -351,6 +363,8 @@ def create_file_object(file_type, fs_entry, aip_id):
 
     if file_type == FileType.preservation:
         _add_normalization_date(new_file.id)
+
+    _add_characteristics_extension(fs_entry, new_file.id)
 
 
 def collect_mets_agents(mets):

--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -306,14 +306,12 @@ def _add_normalization_date(file_id):
         db.session.commit()
 
 
-def _add_characteristics_extension(fs_entry, file_id):
-    """Add string representation of PREMIS Object characteristics_extension to File object."""
+def _add_premis_object_with_characteristics_extension(fs_entry, file_id):
+    """Add string representation of PREMIS Object to File object."""
     file_ = File.query.get(file_id)
     for premis_object in fs_entry.get_premis_objects():
         if premis_object.characteristics_extension:
-            file_.characteristics_extension = str(
-                premis_object.characteristics_extension
-            )
+            file_.premis_object = premis_object.tostring()
             db.session.commit()
             return
 
@@ -364,7 +362,7 @@ def create_file_object(file_type, fs_entry, aip_id):
     if file_type == FileType.preservation:
         _add_normalization_date(new_file.id)
 
-    _add_characteristics_extension(fs_entry, new_file.id)
+    _add_premis_object_with_characteristics_extension(fs_entry, new_file.id)
 
 
 def collect_mets_agents(mets):

--- a/AIPscan/Reporter/templates/file.html
+++ b/AIPscan/Reporter/templates/file.html
@@ -66,6 +66,14 @@
       {{ file_.checksum_value }}
     </td>
   </tr>
+  <tr>
+    <td width=20%>
+      <strong>Characterization tool output</strong>
+    </td>
+    <td>
+      {{ file_.characteristics_extension }}
+    </td>
+  </tr>
   {% if preservation_file %}
     <tr>
       <td width=20%>

--- a/AIPscan/Reporter/templates/file.html
+++ b/AIPscan/Reporter/templates/file.html
@@ -66,14 +66,16 @@
       {{ file_.checksum_value }}
     </td>
   </tr>
+  {% if file_.premis_object %}
   <tr>
     <td width=20%>
-      <strong>Characterization tool output</strong>
+      <strong>PREMIS Object XML</strong>
     </td>
     <td>
-      {{ file_.characteristics_extension }}
+      {{ file_.premis_object }}
     </td>
   </tr>
+  {% endif %}
   {% if preservation_file %}
     <tr>
       <td width=20%>

--- a/AIPscan/models.py
+++ b/AIPscan/models.py
@@ -384,6 +384,7 @@ class File(db.Model):
     format_version = db.Column(db.String(255))
     checksum_type = db.Column(db.String(255))
     checksum_value = db.Column(db.String(255), index=True)
+    characteristics_extension = db.Column(db.Text())
 
     original_file_id = db.Column(db.Integer(), db.ForeignKey("file.id"))
     original_file = db.relationship(
@@ -405,6 +406,7 @@ class File(db.Model):
         checksum_value,
         aip_id,
         file_type=FileType.original,
+        characteristics_extension=None,
         format_version=None,
         puid=None,
         original_file_id=None,
@@ -420,6 +422,7 @@ class File(db.Model):
         self.format_version = format_version
         self.checksum_type = checksum_type
         self.checksum_value = checksum_value
+        self.characteristics_extension = characteristics_extension
         self.original_file_id = original_file_id
         self.aip_id = aip_id
 

--- a/AIPscan/models.py
+++ b/AIPscan/models.py
@@ -384,7 +384,7 @@ class File(db.Model):
     format_version = db.Column(db.String(255))
     checksum_type = db.Column(db.String(255))
     checksum_value = db.Column(db.String(255), index=True)
-    characteristics_extension = db.Column(db.Text())
+    premis_object = db.Column(db.Text())
 
     original_file_id = db.Column(db.Integer(), db.ForeignKey("file.id"))
     original_file = db.relationship(
@@ -406,7 +406,7 @@ class File(db.Model):
         checksum_value,
         aip_id,
         file_type=FileType.original,
-        characteristics_extension=None,
+        premis_object=None,
         format_version=None,
         puid=None,
         original_file_id=None,
@@ -422,7 +422,7 @@ class File(db.Model):
         self.format_version = format_version
         self.checksum_type = checksum_type
         self.checksum_value = checksum_value
-        self.characteristics_extension = characteristics_extension
+        self.premis_object = premis_object
         self.original_file_id = original_file_id
         self.aip_id = aip_id
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ Jinja2==2.11.3
 kombu==4.6.10
 lxml==4.6.5
 MarkupSafe==1.1.1
-metsrw==0.3.15
+metsrw==0.3.22
 natsort==7.0.1
 pandas==1.1.4
 plotly==5.7.0


### PR DESCRIPTION
This PR adds the PREMIS Object XML for files that have a `premis:objectCharacteristicsExtension`. This allows for users to see characterization tool output in its XML form within AIPscan.

This currently doesn't work due to https://github.com/artefactual-labs/mets-reader-writer/issues/94. First, https://github.com/artefactual-labs/mets-reader-writer/pull/96 will need to be merged and then a `0.3.22` release of `metsrw` uploaded to PyPI. 

Commit https://github.com/artefactual-labs/AIPscan/pull/180/commits/c3a098dd3b271d1dee10d233bc97cb5974d36d29 is left here for now to show what is possible without serializing the PREMISObject to XML - the result is that the tuple representation of the characteristics extension is stored in the database, which is harder for users to read.