### PR TITLE
Use correct variable at "deleted AIPs" statistic

### DIFF
--- a/AIPscan/Aggregator/templates/storage_service.html
+++ b/AIPscan/Aggregator/templates/storage_service.html
@@ -66,7 +66,7 @@
                 {{ mets_fetch_job.total_sips }} SIPs <br>
                 {{ mets_fetch_job.total_dips }} DIPs <br>
                 {{ mets_fetch_job.total_replicas }} AIP replicas<br>
-                {{ mets_fetch_job.total_replicas }} deleted AIPs <br>
+                {{ mets_fetch_job.total_deleted_aips }} deleted AIPs <br>
               </small>
           </span>
           </div>


### PR DESCRIPTION
Variable for total_replicas is also used at deleted AIPs.

This pull request changes that variable to the correct one.

Issue: https://github.com/artefactual-labs/AIPscan/issues/182#issue-1383926163