### PR TITLE
Fix to PREMIS Object XML display.

### DIFF
--- a/AIPscan/Aggregator/database_helpers.py
+++ b/AIPscan/Aggregator/database_helpers.py
@@ -314,7 +314,7 @@ def _add_premis_object_xml(fs_entry, file_id):
         for ss in fs_entry.amdsecs[0].subsections:
             if ss.contents.mdtype == fs_entry.PREMIS_OBJECT:
                 file_.premis_object = etree.tostring(
-                    ss.contents.serialize(), pretty_print=True
+                    ss.contents.serialize(), encoding="unicode", pretty_print=True
                 )
         db.session.commit()
 

--- a/AIPscan/Reporter/helpers.py
+++ b/AIPscan/Reporter/helpers.py
@@ -128,3 +128,20 @@ def get_display_end_date(end_date):
     :return: End date minus one day (datetime.datetime object)
     """
     return end_date - timedelta(days=1)
+
+
+def get_premis_xml_lines(file_object):
+    """Get list of lines of XML from a file's PREMIS object XML field.
+
+    Get list of lines from a file object's PREMIS object XML property, if
+    not empty.
+
+    :param file_object: AIPscan.models.File object
+
+    :return: List of XML lines (list of str)
+    """
+    premis_xml_lines = []
+    if file_object.premis_object is not None:
+        premis_xml_lines = file_object.premis_object.split("\n")
+
+    return premis_xml_lines

--- a/AIPscan/Reporter/tests/test_helpers.py
+++ b/AIPscan/Reporter/tests/test_helpers.py
@@ -1,4 +1,6 @@
 import csv
+import datetime
+import uuid
 
 import pytest
 
@@ -9,6 +11,7 @@ from AIPscan.Data.tests import (
 )
 from AIPscan.Data.tests import MOCK_STORAGE_SERVICE as STORAGE_SERVICE
 from AIPscan.Data.tests import MOCK_STORAGE_SERVICE_ID as STORAGE_SERVICE_ID
+from AIPscan.models import File, FileType
 from AIPscan.Reporter import helpers
 from AIPscan.Reporter.report_aips_by_format import HEADERS
 
@@ -103,3 +106,26 @@ def test_download_csv(app_instance, mocker):
 def test_format_size_for_csv(data, expected_output):
     """Test formatting size in report endpoint data."""
     assert helpers.format_size_for_csv(data) == expected_output
+
+
+def test_get_premis_xml_lines():
+    premis_xml = "First line\nSecond line"
+
+    file_ = File(
+        uuid=uuid.uuid4(),
+        name="test.txt",
+        size=12345,
+        aip_id=2,
+        file_type=FileType.original,
+        file_format="Plain Text File",
+        puid="x-fmt/111",
+        filepath="/path/to/file.txt",
+        date_created=datetime.datetime.now(),
+        checksum_type="md5",
+        checksum_value="anotherfakemd5",
+        premis_object=premis_xml,
+    )
+
+    lines = helpers.get_premis_xml_lines(file_)
+
+    assert len(lines) == 2

--- a/AIPscan/Reporter/views.py
+++ b/AIPscan/Reporter/views.py
@@ -37,6 +37,7 @@ from AIPscan.Reporter import (  # noqa: F401
     request_params,
     sort_puids,
 )
+from AIPscan.Reporter.helpers import get_premis_xml_lines
 
 
 def _get_storage_service(storage_service_id):
@@ -163,7 +164,7 @@ def view_file(file_id):
     return render_template(
         "file.html",
         file_=file_,
-        premisxml=file_.premis_object.decode("utf-8").split("\\n"),
+        premisxml=get_premis_xml_lines(file_),
         aip=aip,
         events=events,
         preservation_file=preservation_file,


### PR DESCRIPTION
Changed storage of PREMIS object XML from binary to Unicode.

Added logic to make sure that there is PREMIS object XML before populating list of PREMIS object XML lines.