### PR TITLE
Update precommit check isort version.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: flake8
     language_version: python3
 - repo: https://github.com/pycqa/isort
-  rev: 5.6.4
+  rev: 5.11.5
   hooks:
   - id: isort
     language_version: python3


### PR DESCRIPTION
Update isort to 5.11.5 to address issue that occurs in relation of a isort's dependencies.

Error output example:

https://github.com/home-assistant/core/issues/86892

Release tag:

https://github.com/PyCQA/isort/releases/tag/5.11.5