### PR TITLE
Update GitHub Actions workflow Ubuntu version.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tox:
     name: "Test ${{ matrix.toxenv }}"
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     strategy:
       matrix:
         include:
@@ -63,7 +63,7 @@ jobs:
           flags: ${{ matrix.toxenv }}
   lint:
     name: "Lint"
-    runs-on: "ubuntu-18.04"
+    runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v2"


### PR DESCRIPTION
Update GitHub Actions workflow Ubuntu version.
    
Updated GitHub Actions workflow Ubuntu runner image version from 18.04 to 20.04, given that the 18.04 runner image is depricated and will stop working on April 1, 2023.
    
See: https://github.com/actions/runner-images/issues/6002