### PR TITLE
Update Github workflow's actions to use Node16.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,9 @@ jobs:
             toxenv: "py39"
     steps:
       - name: "Check out repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v3"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install OS packages"
@@ -66,9 +66,9 @@ jobs:
     runs-on: "ubuntu-20.04"
     steps:
       - name: "Check out repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Set up Python"
-        uses: "actions/setup-python@v2"
+        uses: "actions/setup-python@v3"
         with:
           python-version: "3.8"
       - name: "Install tox"


### PR DESCRIPTION
See:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/