### PR TITLE
Update AIPScan database with deleted SS AIPs, #199

### DIFF
--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -114,6 +114,10 @@ def parse_packages_and_load_mets(
     for package_obj in package_list.get(OBJECTS, []):
         package = process_package_object(package_obj)
         packages.append(package)
+
+        if package.is_deleted():
+            delete_aip(package.uuid)
+
         if not package.is_aip():
             continue
         start_mets_task(
@@ -129,6 +133,16 @@ def parse_packages_and_load_mets(
             fetch_job_id,
         )
     return packages
+
+
+def delete_aip(uuid):
+    logger.warning("Package deleted from SS: '%s'", uuid)
+
+    deleted_aip = AIP.query.filter_by(uuid=uuid).first()
+
+    if deleted_aip is not None:
+        logger.warning("Deleting AIP: %s", uuid)
+        database_helpers.delete_aip_object(deleted_aip)
 
 
 @celery.task(bind=True)

--- a/AIPscan/Aggregator/tests/test_tasks.py
+++ b/AIPscan/Aggregator/tests/test_tasks.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import uuid
 from datetime import datetime
 from io import StringIO
 
@@ -9,6 +10,7 @@ import pytest
 from AIPscan import test_helpers
 from AIPscan.Aggregator.tasks import (
     TaskError,
+    delete_aip,
     get_mets,
     make_request,
     parse_packages_and_load_mets,
@@ -208,3 +210,18 @@ def test_parse_packages_and_load_mets(app_instance, tmpdir, mocker):
     parse_packages_and_load_mets(json_file_path, {}, str(datetime.now()), 1, 1, 1)
 
     delete_package_json.assert_called_with(json_file_path)
+
+
+def test_delete_aip(app_instance):
+    """Test that SS deleted AIPs gets deleted in aipscan.db."""
+    PACKAGE_UUID = str(uuid.uuid4())
+
+    test_helpers.create_test_aip(uuid=PACKAGE_UUID)
+
+    deleted_aip = AIP.query.filter_by(uuid=PACKAGE_UUID).first()
+    assert deleted_aip is not None
+
+    delete_aip(PACKAGE_UUID)
+
+    deleted_aip = AIP.query.filter_by(uuid=PACKAGE_UUID).first()
+    assert deleted_aip is None


### PR DESCRIPTION
[Related Issue: AIPScan database not updated if AIP deleted from storage service #199](https://github.com/artefactual-labs/AIPscan/issues/199)

When user runs "New Fetch Job", it will check each package to see if it's been deleted. If so, it will delete the aip from the aipscan.db.