### PR TITLE
Make storage service deletion Celery task. (#204)

### DIFF
--- a/AIPscan/Aggregator/tests/test_tasks.py
+++ b/AIPscan/Aggregator/tests/test_tasks.py
@@ -12,6 +12,7 @@ from AIPscan.Aggregator.tasks import (
     TaskError,
     delete_aip,
     delete_fetch_job,
+    delete_storage_service,
     get_mets,
     make_request,
     parse_packages_and_load_mets,
@@ -24,7 +25,7 @@ from AIPscan.Aggregator.tests import (
     VALID_JSON,
     MockResponse,
 )
-from AIPscan.models import AIP, FetchJob
+from AIPscan.models import AIP, FetchJob, StorageService
 
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURES_DIR = os.path.join(SCRIPT_DIR, "fixtures")
@@ -192,6 +193,19 @@ def test_delete_fetch_job_task(app_instance, tmpdir, mocker):
     delete_fetch_job(fetch_job1.id)
 
     assert FetchJob.query.filter_by(id=fetch_job1.id).first() is None
+
+
+def test_delete_storage_service_task(app_instance, tmpdir, mocker):
+    """Test that storage service gets deleted by delete storage service job task logic."""
+    storage_service = test_helpers.create_test_storage_service()
+
+    deleted_ss = StorageService.query.filter_by(id=storage_service.id).first()
+    assert deleted_ss is not None
+
+    delete_storage_service(storage_service.id)
+
+    deleted_ss = StorageService.query.filter_by(id=storage_service.id).first()
+    assert deleted_ss is None
 
 
 @pytest.mark.parametrize(

--- a/AIPscan/Aggregator/views.py
+++ b/AIPscan/Aggregator/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import shutil
 from datetime import datetime
 
 from celery.result import AsyncResult
@@ -151,14 +150,9 @@ def new_storage_service():
 
 @aggregator.route("/delete_storage_service/<id>", methods=["GET"])
 def delete_storage_service(id):
+    tasks.delete_storage_service.delay(id)
     storage_service = StorageService.query.get(id)
-    mets_fetch_jobs = FetchJob.query.filter_by(storage_service_id=id).all()
-    for mets_fetch_job in mets_fetch_jobs:
-        if os.path.exists(mets_fetch_job.download_directory):
-            shutil.rmtree(mets_fetch_job.download_directory)
-    db.session.delete(storage_service)
-    db.session.commit()
-    flash("Storage service '{}' is deleted".format(storage_service.name))
+    flash("Storage service '{}' is being deleted".format(storage_service.name))
     return redirect(url_for("aggregator.storage_services"))
 
 


### PR DESCRIPTION
Move storage service deletion logic into a Celery task to avoid timeouts.