### PR TITLE
Use server-side paging in aips page. (#209)

### DIFF
--- a/AIPscan/Reporter/helpers.py
+++ b/AIPscan/Reporter/helpers.py
@@ -145,3 +145,14 @@ def get_premis_xml_lines(file_object):
         premis_xml_lines = file_object.premis_object.split("\n")
 
     return premis_xml_lines
+
+
+def calculate_paging_window(pagination):
+    first_item = ((pagination.page - 1) * pagination.per_page) + 1
+    last_item = pagination.page * pagination.per_page
+
+    return first_item, min(last_item, pagination.total)
+
+
+def remove_dict_none_values(values):
+    return {index: "" if value is None else value for (index, value) in values.items()}

--- a/AIPscan/Reporter/request_params.py
+++ b/AIPscan/Reporter/request_params.py
@@ -11,6 +11,7 @@ ORIGINAL_FILES = "original_files"
 PUID = "puid"
 STORAGE_LOCATION_ID = "storage_location"
 STORAGE_SERVICE_ID = "amss_id"
+PAGE = "page"
 
 START_DATE = "start_date"
 END_DATE = "end_date"

--- a/AIPscan/Reporter/templates/aips.html
+++ b/AIPscan/Reporter/templates/aips.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<div class="alert alert-header"><strong>AIPs ({{ aips|length }})</strong></div>
+<div class="alert alert-header"><strong>AIPs ({{ pager.items|length }})</strong></div>
 
 {% if storage_services %}
 
@@ -42,9 +42,9 @@
     </div>
   </div>
 
-  {% if aips %}
+  {% if pager.items %}
 
-    <table id="aiptable" class="table table-striped table-bordered">
+    <table id="aipstable" class="table table-striped table-bordered">
       <thead>
       <tr>
       <th><strong>Transfer name</strong></th>
@@ -54,19 +54,17 @@
       <th><strong>Preservation copies</strong></th>
       <th><strong>Action</strong></th>
       </tr>
-      </thead>
-      {% if aips %}
-        {% for aip in aips %}
-          <tr>
-            <td>{{ aip.transfer_name }}</td>
-            <td>{{ aip.uuid }}</td>
-            <td>{{ aip.create_date }}</td>
-            <td>{{ aip.original_file_count }}</td>
-            <td>{{ aip.preservation_file_count }}</td>
-            <td><a href='{{ url_for("reporter.view_aip", aip_id = aip.id) }}'><button type="button" class="btn btn-info">View</button></a></td>
-          </tr>
-        {% endfor %}
-      {% endif %}
+
+      {% for aip in pager.items %}
+        <tr>
+          <td>{{ aip.transfer_name }}</td>
+          <td>{{ aip.uuid }}</td>
+          <td>{{ aip.create_date }}</td>
+          <td>{{ aip.original_file_count }}</td>
+          <td>{{ aip.preservation_file_count }}</td>
+          <td><a href='{{ url_for("reporter.view_aip", aip_id = aip.id) }}'><button type="button" class="btn btn-info">View</button></a></td>
+        </tr>
+      {% endfor %}
     </table>
 
   {% else %}
@@ -81,6 +79,29 @@
 
   <div style="padding:1em;">
       Storage Service information is not yet available for reporting. <a href="{{ url_for('aggregator.storage_services') }}">Configure a Storage Service</a> and run a Fetch Job to get started.</a>
+  </div>
+
+{% endif %}
+
+{% if pager.total %}
+
+  <div class="dataTables_wrapper">
+    <div class="row">
+      <div class="col-sm-12 col-md-5">
+        <div class="dataTables_info" id="aiptable_info" role="status" aria-live="polite">Showing {{ first_item }} to {{ last_item }} of {{ pager.total }} entries</div>
+      </div>
+      <div class="col-sm-12 col-md-7">
+        <div class="dataTables_paginate paging_full_numbers" id="aiptable_paginate">
+          <ul class="pagination">
+            <li class="paginate_button page-item first {% if pager.page == 1 %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aips', page=1, **state_query_params) }}" class="page-link">First</a></li>
+            <li class="paginate_button page-item previous {% if pager.prev_num is none %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aips', page=pager.prev_num, **state_query_params) }}" class="page-link">Previous</a></li>
+            <li class="paginate_button page-item active"><a href="#" class="page-link">{{ pager.page }}</a></li>
+            <li class="paginate_button page-item next {% if pager.next_num is none %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aips', page=pager.next_num, **state_query_params) }}" class="page-link">Next</a></li>
+            <li class="paginate_button page-item last {% if pager.page == pager.pages %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aips', page=pager.pages, **state_query_params) }}" class="page-link">Last</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
 
 {% endif %}

--- a/AIPscan/Reporter/tests/test_helpers.py
+++ b/AIPscan/Reporter/tests/test_helpers.py
@@ -129,3 +129,39 @@ def test_get_premis_xml_lines():
     lines = helpers.get_premis_xml_lines(file_)
 
     assert len(lines) == 2
+
+
+@pytest.mark.parametrize(
+    "paging",
+    [
+        # Test paging window at start of results
+        {"per_page": 5, "total": 17, "page": 1, "first_item": 1, "last_item": 5},
+        # Test paging window on an arbitrary page of results
+        {"per_page": 5, "total": 17, "page": 3, "first_item": 11, "last_item": 15},
+        # Test paging window with last item being set to the total of items
+        {"per_page": 5, "total": 17, "page": 4, "first_item": 16, "last_item": 17},
+        # Test paging window at start of results with incomplete page
+        {"per_page": 7, "total": 4, "page": 1, "first_item": 1, "last_item": 4},
+    ],
+)
+def test_calculate_paging_window(paging):
+    class MockPagination(object):
+        pass
+
+    pagination = MockPagination()
+    pagination.page = paging["page"]
+    pagination.per_page = paging["per_page"]
+    pagination.total = paging["total"]
+
+    first_item, last_item = helpers.calculate_paging_window(pagination)
+
+    assert first_item == paging["first_item"]
+    assert last_item == paging["last_item"]
+
+
+def test_remove_dict_none_values():
+    test_values = {"foo": "bar", "nada": None}
+
+    querystring = helpers.remove_dict_none_values(test_values)
+
+    assert querystring == {"foo": "bar", "nada": ""}


### PR DESCRIPTION
To avoid slow page responses when there are a large amount of AIPs use server-side paging to limit the number of AIP HTML sent to the browser.