### PR TITLE
Use server-side paging in aip files page. (#216)

### DIFF
--- a/AIPscan/Reporter/templates/aip.html
+++ b/AIPscan/Reporter/templates/aip.html
@@ -28,7 +28,7 @@
 
 <h3>Original files</h3>
 
-<table id="aiptable" class="table table-striped table-bordered">
+<table id="aipstable" class="table table-striped table-bordered">
   <thead>
   <tr>
   <th><strong>Name</strong></th>
@@ -81,5 +81,28 @@
     {% endfor %}
   {% endif %}
 </table>
+
+{% if pager.total %}
+
+  <div class="dataTables_wrapper">
+    <div class="row">
+      <div class="col-sm-12 col-md-5">
+        <div class="dataTables_info" id="aiptable_info" role="status" aria-live="polite">Showing {{ first_item }} to {{ last_item }} of {{ pager.total }} entries</div>
+      </div>
+      <div class="col-sm-12 col-md-7">
+        <div class="dataTables_paginate paging_full_numbers" id="aiptable_paginate">
+          <ul class="pagination">
+            <li class="paginate_button page-item first {% if pager.page == 1 %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aip', aip_id=aip.id, page=1) }}" class="page-link">First</a></li>
+            <li class="paginate_button page-item previous {% if pager.prev_num is none %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aip', aip_id=aip.id, page=pager.prev_num) }}" class="page-link">Previous</a></li>
+            <li class="paginate_button page-item active"><a href="#" class="page-link">{{ pager.page }}</a></li>
+            <li class="paginate_button page-item next {% if pager.next_num is none %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aip', aip_id=aip.id, page=pager.next_num) }}" class="page-link">Next</a></li>
+            <li class="paginate_button page-item last {% if pager.page == pager.pages %}disabled{% endif %}"><a href="{{ url_for('reporter.view_aip', aip_id=aip.id, page=pager.pages) }}" class="page-link">Last</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+
+{% endif %}
 
 {% endblock %}

--- a/AIPscan/Reporter/tests/test_views.py
+++ b/AIPscan/Reporter/tests/test_views.py
@@ -58,3 +58,22 @@ def test_get_aip_pager(app_instance, mocker, page, pager_page):
     assert pager.per_page == 2
     assert pager.prev_num is None
     assert pager.next_num is None
+
+
+@pytest.mark.parametrize("page,pager_page", [(1, 1), ("bad", 1)])
+def test_get_file_pager(app_instance, mocker, page, pager_page):
+    paginate_mock = mocker.Mock()
+    filter_by_mock = mocker.Mock()
+    filter_by_mock.paginate.return_value = paginate_mock
+
+    query_mock = mocker.Mock()
+    query_mock.filter_by.return_value = filter_by_mock
+
+    aip = test_helpers.create_test_aip()
+    pager = views.get_file_pager(page, 2, aip)
+
+    assert pager.page == pager_page
+    assert pager.pages == 0
+    assert pager.per_page == 2
+    assert pager.prev_num is None
+    assert pager.next_num is None

--- a/AIPscan/templates/datatable.html
+++ b/AIPscan/templates/datatable.html
@@ -10,11 +10,6 @@
 
     <script type="text/javascript" class="init">
         $(document).ready(function() {
-            $('#aiptable').DataTable( {
-              "lengthMenu": [[10, 30, 60, -1], [10, 30, 60, "All"]],
-              "pageLength": 10,
-              "pagingType": "full_numbers",
-            });
             $('#aiptable2').DataTable( {
                 "lengthMenu": [[10, 30, 60, -1], [10, 30, 60, "All"]],
                 "pageLength": 10,


### PR DESCRIPTION
To avoid slow page responses, when there are a large amount of files in an AIP, use server-side paging to limit the amount of AIP file HTML sent to the browser.