### PR TITLE
Bump urllib3 from 1.26.17 to 1.26.18.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ pytz==2020.1
 requests==2.27.1
 six==1.14.0
 SQLAlchemy==1.3.15
-urllib3==1.26.17
+urllib3==1.26.18
 vine==1.3.0
 Werkzeug== 2.0.3
 WTForms==2.2.1


### PR DESCRIPTION
To address this moderate vulnerability:

https://nvd.nist.gov/vuln/detail/CVE-2023-45803