### PR TITLE
Use file extensions for test file formats (#244)

### DIFF
--- a/tools/helpers/data.py
+++ b/tools/helpers/data.py
@@ -119,7 +119,7 @@ def create_fake_aip_files(min, max, aip_id):
             size=randint(1000, 1_000_000),
             date_created=date.today(),
             puid=fake.text(20)[:-1],
-            file_format=fake.text(20)[:-1],
+            file_format=fake.file_extension(),
             format_version=fake.text(20)[:-1],
             checksum_type=fake.text(20)[:-1],
             checksum_value=fake.text(20)[:-1],


### PR DESCRIPTION
The test data generation tool was generating files whose file formats were random text. Change this to use file extensions as file formats in order to have data closer to normal data (so the file formats count pie chart will display correctly, etc.).