### PR TITLE
Add sortable size CSV field (#149)

### DIFF
--- a/AIPscan/Data/fields.py
+++ b/AIPscan/Data/fields.py
@@ -53,6 +53,7 @@ FIELD_PUID = "PUID"
 FIELD_RELATED_PAIRING = "RelatedPairing"
 
 FIELD_SIZE = "Size"
+FIELD_SIZE_BYTES = "SizeBytes"
 FIELD_STORAGE_LOCATION = "StorageLocation"
 FIELD_STORAGE_NAME = "StorageName"
 

--- a/AIPscan/Reporter/report_aip_contents.py
+++ b/AIPscan/Reporter/report_aip_contents.py
@@ -22,7 +22,7 @@ CSV_HEADERS = [
     fields.FIELD_FORMATS,
 ]
 
-HEADERS = [
+TABLE_HEADERS = [
     fields.FIELD_AIP_NAME,
     fields.FIELD_CREATED_DATE,
     fields.FIELD_SIZE,
@@ -110,8 +110,9 @@ def aip_contents():
     )
 
     if csv:
+        headers = translate_headers(CSV_HEADERS, True)
+
         filename = "aip_contents.csv"
-        headers = translate_headers(CSV_HEADERS)
         aips = _create_aip_formats_string_representation(
             aip_data.get(fields.FIELD_AIPS), separator="|"
         )
@@ -120,12 +121,14 @@ def aip_contents():
 
     aips = _create_aip_formats_string_representation(aip_data.get(fields.FIELD_AIPS))
 
+    headers = translate_headers(TABLE_HEADERS)
+
     return render_template(
         "report_aip_contents.html",
         storage_service=storage_service_id,
         storage_service_name=aip_data.get(fields.FIELD_STORAGE_NAME),
         storage_location_description=aip_data.get(fields.FIELD_STORAGE_LOCATION),
-        columns=translate_headers(HEADERS),
+        columns=headers,
         aips=aip_data.get(fields.FIELD_AIPS),
         start_date=start_date,
         end_date=get_display_end_date(end_date),

--- a/AIPscan/Reporter/report_aips_by_format.py
+++ b/AIPscan/Reporter/report_aips_by_format.py
@@ -28,8 +28,6 @@ def aips_by_format():
     original_files = parse_bool(request.args.get(request_params.ORIGINAL_FILES, True))
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    headers = translate_headers(HEADERS)
-
     aip_data = report_data.aips_by_file_format(
         storage_service_id=storage_service_id,
         file_format=file_format,
@@ -38,9 +36,13 @@ def aips_by_format():
     )
 
     if csv:
+        headers = translate_headers(HEADERS, True)
+
         filename = "aips_by_file_format_{}.csv".format(file_format)
         csv_data = format_size_for_csv(aip_data[fields.FIELD_AIPS])
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_aips_by_format.html",

--- a/AIPscan/Reporter/report_aips_by_puid.py
+++ b/AIPscan/Reporter/report_aips_by_puid.py
@@ -53,8 +53,6 @@ def aips_by_puid():
     original_files = parse_bool(request.args.get(request_params.ORIGINAL_FILES, True))
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    headers = translate_headers(HEADERS)
-
     aip_data = report_data.aips_by_puid(
         storage_service_id=storage_service_id,
         puid=puid,
@@ -63,9 +61,13 @@ def aips_by_puid():
     )
 
     if csv:
+        headers = translate_headers(HEADERS, True)
+
         filename = "aips_by_puid_{}.csv".format(puid)
         csv_data = format_size_for_csv(aip_data[fields.FIELD_AIPS])
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_aips_by_puid.html",

--- a/AIPscan/Reporter/report_format_versions_count.py
+++ b/AIPscan/Reporter/report_format_versions_count.py
@@ -41,12 +41,14 @@ def report_format_versions_count():
     )
     versions = version_data.get(fields.FIELD_FORMAT_VERSIONS)
 
-    headers = translate_headers(HEADERS)
-
     if csv:
+        headers = translate_headers(HEADERS, True)
+
         filename = "format_versions.csv"
         csv_data = format_size_for_csv(versions)
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_format_versions_count.html",

--- a/AIPscan/Reporter/report_formats_count.py
+++ b/AIPscan/Reporter/report_formats_count.py
@@ -51,12 +51,14 @@ def report_formats_count():
     )
     formats = formats_data.get(fields.FIELD_FORMATS)
 
-    headers = translate_headers(HEADERS)
-
     if csv:
+        headers = translate_headers(HEADERS, True)
+
         filename = "file_formats.csv"
         csv_data = format_size_for_csv(formats)
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_formats_count.html",

--- a/AIPscan/Reporter/report_largest_aips.py
+++ b/AIPscan/Reporter/report_largest_aips.py
@@ -35,8 +35,6 @@ def largest_aips():
         pass
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    headers = translate_headers(HEADERS)
-
     aip_data = report_data.largest_aips(
         storage_service_id=storage_service_id,
         start_date=start_date,
@@ -46,10 +44,13 @@ def largest_aips():
     )
 
     if csv:
+        headers = translate_headers(HEADERS, True)
+
         filename = "largest_aips.csv"
-        headers = translate_headers(HEADERS)
         csv_data = format_size_for_csv(aip_data[fields.FIELD_AIPS])
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_largest_aips.html",

--- a/AIPscan/Reporter/report_largest_files.py
+++ b/AIPscan/Reporter/report_largest_files.py
@@ -13,7 +13,7 @@ from AIPscan.Reporter import (
     translate_headers,
 )
 
-HEADERS = [
+TABLE_HEADERS = [
     fields.FIELD_FILENAME,
     fields.FIELD_SIZE,
     fields.FIELD_FORMAT,
@@ -52,8 +52,6 @@ def largest_files():
         pass
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    headers = translate_headers(HEADERS)
-
     file_data = report_data.largest_files(
         storage_service_id=storage_service_id,
         start_date=start_date,
@@ -64,10 +62,13 @@ def largest_files():
     )
 
     if csv:
+        headers = translate_headers(CSV_HEADERS, True)
+
         filename = "largest_files.csv"
-        headers = translate_headers(CSV_HEADERS)
         csv_data = format_size_for_csv(file_data[fields.FIELD_FILES])
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(TABLE_HEADERS)
 
     return render_template(
         "report_largest_files.html",

--- a/AIPscan/Reporter/report_storage_locations.py
+++ b/AIPscan/Reporter/report_storage_locations.py
@@ -38,17 +38,19 @@ def storage_locations():
     )
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    headers = translate_headers(HEADERS)
-
     locations_data = report_data.storage_locations(
         storage_service_id=storage_service_id, start_date=start_date, end_date=end_date
     )
     locations = locations_data.get(fields.FIELD_LOCATIONS)
 
     if csv:
+        headers = translate_headers(HEADERS, True)
+
         filename = "storage_locations.csv"
         csv_data = format_size_for_csv(locations)
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_storage_locations.html",

--- a/AIPscan/Reporter/tests/test_aip_contents.py
+++ b/AIPscan/Reporter/tests/test_aip_contents.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-EXPECTED_CSV_CONTENTS = b"UUID,AIP Name,Created Date,Size,Formats\r\n111111111111-1111-1111-11111111,Test AIP,2020-01-01 00:00:00,0 Bytes,fmt/43 (ACME File Format 0.0.0): 1 file|fmt/61 (ACME File Format 0.0.0): 1 file\r\n222222222222-2222-2222-22222222,Test AIP,2020-06-01 00:00:00,0 Bytes,x-fmt/111 (ACME File Format 0.0.0): 3 files|fmt/61 (ACME File Format 0.0.0): 2 files\r\n"
+EXPECTED_CSV_CONTENTS = b"UUID,AIP Name,Created Date,Size,Size (bytes),Formats\r\n111111111111-1111-1111-11111111,Test AIP,2020-01-01 00:00:00,0 Bytes,0,fmt/43 (ACME File Format 0.0.0): 1 file|fmt/61 (ACME File Format 0.0.0): 1 file\r\n222222222222-2222-2222-22222222,Test AIP,2020-06-01 00:00:00,0 Bytes,0,x-fmt/111 (ACME File Format 0.0.0): 3 files|fmt/61 (ACME File Format 0.0.0): 2 files\r\n"
 
 
 def test_aip_contents(aip_contents):

--- a/AIPscan/Reporter/tests/test_aips_by_file_format.py
+++ b/AIPscan/Reporter/tests/test_aips_by_file_format.py
@@ -1,12 +1,8 @@
 import pytest
 from flask import current_app
 
-EXPECTED_CSV_ORIGINAL = (
-    b"AIP Name,UUID,Count,Size\r\nTest AIP,111111111111-1111-1111-11111111,1,1.0 kB\r\n"
-)
-EXPECTED_CSV_PRESERVATION = (
-    b"AIP Name,UUID,Count,Size\r\nTest AIP,111111111111-1111-1111-11111111,1,2.0 kB\r\n"
-)
+EXPECTED_CSV_ORIGINAL = b"AIP Name,UUID,Count,Size,Size (bytes)\r\nTest AIP,111111111111-1111-1111-11111111,1,1.0 kB,1000\r\n"
+EXPECTED_CSV_PRESERVATION = b"AIP Name,UUID,Count,Size,Size (bytes)\r\nTest AIP,111111111111-1111-1111-11111111,1,2.0 kB,2000\r\n"
 
 
 @pytest.mark.parametrize(

--- a/AIPscan/Reporter/tests/test_aips_by_puid.py
+++ b/AIPscan/Reporter/tests/test_aips_by_puid.py
@@ -7,12 +7,8 @@ from flask import current_app
 from AIPscan.models import File, FileType
 from AIPscan.Reporter.report_aips_by_puid import get_format_string_from_puid
 
-EXPECTED_CSV_ORIGINAL = (
-    b"AIP Name,UUID,Count,Size\r\nTest AIP,111111111111-1111-1111-11111111,1,1.0 kB\r\n"
-)
-EXPECTED_CSV_PRESERVATION = (
-    b"AIP Name,UUID,Count,Size\r\nTest AIP,111111111111-1111-1111-11111111,1,2.0 kB\r\n"
-)
+EXPECTED_CSV_ORIGINAL = b"AIP Name,UUID,Count,Size,Size (bytes)\r\nTest AIP,111111111111-1111-1111-11111111,1,1.0 kB,1000\r\n"
+EXPECTED_CSV_PRESERVATION = b"AIP Name,UUID,Count,Size,Size (bytes)\r\nTest AIP,111111111111-1111-1111-11111111,1,2.0 kB,2000\r\n"
 
 FILE_WITH_FORMAT_ONLY = File(
     uuid=uuid.uuid4(),

--- a/AIPscan/Reporter/tests/test_format_versions_count.py
+++ b/AIPscan/Reporter/tests/test_format_versions_count.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-EXPECTED_CSV_CONTENTS = b"PUID,Format,Version,Count,Size\r\nfmt/44,JPEG,1.02,1,2.0 kB\r\nfmt/43,JPEG,1.01,1,1.0 kB\r\nfmt/468,ISO Disk Image File,,1,0 Bytes\r\n"
+EXPECTED_CSV_CONTENTS = b"PUID,Format,Version,Count,Size,Size (bytes)\r\nfmt/44,JPEG,1.02,1,2.0 kB,2000\r\nfmt/43,JPEG,1.01,1,1.0 kB,1000\r\nfmt/468,ISO Disk Image File,,1,0 Bytes,0\r\n"
 
 
 def test_format_versions_count(app_with_populated_format_versions):

--- a/AIPscan/Reporter/tests/test_formats_count.py
+++ b/AIPscan/Reporter/tests/test_formats_count.py
@@ -1,8 +1,6 @@
 from flask import current_app
 
-EXPECTED_CSV_CONTENTS = (
-    b"Format,Count,Size\r\nJPEG,2,3.0 kB\r\nISO Disk Image File,1,0 Bytes\r\n"
-)
+EXPECTED_CSV_CONTENTS = b"Format,Count,Size,Size (bytes)\r\nJPEG,2,3.0 kB,3000\r\nISO Disk Image File,1,0 Bytes,0\r\n"
 
 
 def test_formats_count(app_with_populated_format_versions):

--- a/AIPscan/Reporter/tests/test_largest_aips.py
+++ b/AIPscan/Reporter/tests/test_largest_aips.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-EXPECTED_CSV_CONTENTS = b"AIP Name,UUID,AIP Size,File Count\r\nTest AIP,111111111111-1111-1111-11111111,100 Bytes,1\r\nTest AIP,222222222222-2222-2222-22222222,100 Bytes,2\r\n"
+EXPECTED_CSV_CONTENTS = b"AIP Name,UUID,AIP Size,AIP Size (bytes),File Count\r\nTest AIP,111111111111-1111-1111-11111111,100 Bytes,100,1\r\nTest AIP,222222222222-2222-2222-22222222,100 Bytes,100,2\r\n"
 
 
 def test_largest_aips(app_with_populated_format_versions):

--- a/AIPscan/Reporter/tests/test_largest_files.py
+++ b/AIPscan/Reporter/tests/test_largest_files.py
@@ -1,6 +1,6 @@
 from flask import current_app
 
-EXPECTED_CSV_CONTENTS = b"UUID,Filename,Size,Type,Format,Version,PUID,AIP Name,AIP UUID\r\n555555555555-5555-5555-55555555,preservation.jpg,2.0 kB,original,JPEG,1.02,fmt/44,Test AIP,222222222222-2222-2222-22222222\r\n333333333333-3333-3333-33333333,original.jpg,1.0 kB,original,JPEG,1.01,fmt/43,Test AIP,111111111111-1111-1111-11111111\r\n444444444444-4444-4444-44444444,original.iso,0 Bytes,original,ISO Disk Image File,,fmt/468,Test AIP,222222222222-2222-2222-22222222\r\n"
+EXPECTED_CSV_CONTENTS = b"UUID,Filename,Size,Size (bytes),Type,Format,Version,PUID,AIP Name,AIP UUID\r\n555555555555-5555-5555-55555555,preservation.jpg,2.0 kB,2000,original,JPEG,1.02,fmt/44,Test AIP,222222222222-2222-2222-22222222\r\n333333333333-3333-3333-33333333,original.jpg,1.0 kB,1000,original,JPEG,1.01,fmt/43,Test AIP,111111111111-1111-1111-11111111\r\n444444444444-4444-4444-44444444,original.iso,0 Bytes,0,original,ISO Disk Image File,,fmt/468,Test AIP,222222222222-2222-2222-22222222\r\n"
 
 
 def test_largest_files(app_with_populated_format_versions):

--- a/AIPscan/Reporter/tests/test_storage_locations.py
+++ b/AIPscan/Reporter/tests/test_storage_locations.py
@@ -6,7 +6,7 @@ from flask import current_app
 SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 FIXTURES_DIR = os.path.join(SCRIPT_DIR, "fixtures")
 
-EXPECTED_CSV_CONTENTS = b"UUID,Location,AIPs,Size,File Count\r\n2bbcea40-eb4d-4076-a81d-1ab046e34f6a,AIP Store Location 1,2,1.6 kB,3\r\ne69beb57-0e32-4c45-8db7-9b7723724a05,AIP Store Location 2,1,5.0 kB,2\r\n"
+EXPECTED_CSV_CONTENTS = b"UUID,Location,AIPs,Size,Size (bytes),File Count\r\n2bbcea40-eb4d-4076-a81d-1ab046e34f6a,AIP Store Location 1,2,1.6 kB,1600,3\r\ne69beb57-0e32-4c45-8db7-9b7723724a05,AIP Store Location 2,1,5.0 kB,5000,2\r\n"
 
 
 def test_storage_locations(storage_locations):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,12 +280,18 @@ def report_format_versions_count():
     )
     versions = version_data.get(fields.FIELD_FORMAT_VERSIONS)
 
-    headers = translate_headers(HEADERS)
-
     if csv:
+        # Using the translate_headers function's "True" argument will
+        # have it automatically add an additional size column with the size
+        # data left as the number of bytes, rather than a more human readable
+        # description of the size, to make it easier to sort CSV rows by size
+        headers = translate_headers(HEADERS, True)
+
         filename = "format_versions.csv"
         csv_data = format_size_for_csv(versions)
         return download_csv(headers, csv_data, filename)
+
+    headers = translate_headers(HEADERS)
 
     return render_template(
         "report_format_versions_count.html",


### PR DESCRIPTION
Package and file size values in CSV exports were made to be human readable which was good for legibility, but impeded the ability to sort rows by size. Added automatic population of, whenever size data is included in an export, an additional column containing the "raw" byte value of a package or file size.