### PR TITLE
Use Typesense for some reports (#41)

### DIFF
--- a/AIPscan/Data/__init__.py
+++ b/AIPscan/Data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from AIPscan.Data import fields
 from AIPscan.models import StorageLocation, StorageService
 
 
@@ -40,3 +40,14 @@ def get_storage_location_description(storage_location_id):
         if storage_location:
             description = storage_location.description
     return description
+
+
+def report_dict(storage_service_id, storage_location_id):
+    report = {}
+
+    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
+    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
+        storage_location_id
+    )
+
+    return report

--- a/AIPscan/Data/data.py
+++ b/AIPscan/Data/data.py
@@ -2,11 +2,7 @@
 
 """Data endpoints optimized for providing general overviews of AIPs."""
 
-from AIPscan.Data import (
-    fields,
-    get_storage_location_description,
-    get_storage_service_name,
-)
+from AIPscan.Data import fields, report_dict
 from AIPscan.helpers import _simplify_datetime
 from AIPscan.models import AIP, File, FileType, StorageService
 
@@ -29,7 +25,7 @@ def file_format_aip_overview(
     storage_service_id, original_files=True, storage_location_id=None
 ):
     """Return summary overview of file formats and the AIPs they're in."""
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     formats = {}
     aips = AIP.query.filter_by(storage_service_id=storage_service_id)
     if storage_location_id:
@@ -67,10 +63,7 @@ def file_format_aip_overview(
                 formats[format_key][fields.FIELD_AIPS].append(aip.uuid)
 
     report[fields.FIELD_FORMATS] = formats
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
+
     return report
 
 
@@ -82,7 +75,7 @@ def aip_file_format_overview(
     storage_location_id=None,
 ):
     """Return summary overview of AIPs and their file formats."""
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     report[fields.FIELD_AIPS] = []
     formats = {}
 
@@ -150,10 +143,7 @@ def aip_file_format_overview(
         report[fields.FIELD_AIPS].append(aip_info)
 
     report[fields.FIELD_FORMATS] = formats
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
+
     return report
 
 
@@ -161,7 +151,8 @@ def derivative_overview(storage_service_id, storage_location_id=None):
     """Return a summary of derivatives across AIPs with a mapping
     created between the original format and the preservation copy.
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
+
     aips = AIP.query.filter_by(storage_service_id=storage_service_id)
     if storage_location_id:
         aips = aips.filter_by(storage_location_id=storage_location_id)
@@ -208,8 +199,5 @@ def derivative_overview(storage_service_id, storage_location_id=None):
         all_aips.append(aip_report)
 
     report[fields.FIELD_ALL_AIPS] = all_aips
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
+
     return report

--- a/AIPscan/Data/report_data.py
+++ b/AIPscan/Data/report_data.py
@@ -7,11 +7,7 @@ from operator import itemgetter
 from dateutil.rrule import DAILY, rrule
 
 from AIPscan import db
-from AIPscan.Data import (
-    fields,
-    get_storage_location_description,
-    get_storage_service_name,
-)
+from AIPscan.Data import fields, get_storage_service_name, report_dict
 from AIPscan.models import AIP, Event, File, FileType, StorageLocation, StorageService
 
 VALID_FILE_TYPES = set(item.value for item in FileType)
@@ -80,12 +76,8 @@ def formats_count(storage_service_id, start_date, end_date, storage_location_id=
         report["StorageName"]: Name of Storage Service queried
         report["Formats"]: List of results ordered desc by count and size
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     report[fields.FIELD_FORMATS] = []
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
 
     formats = _formats_count_query(
         storage_service_id, start_date, end_date, storage_location_id
@@ -164,12 +156,8 @@ def format_versions_count(
         report["StorageName"]: Name of Storage Service queried
         report["FormatVersions"]: List of result files ordered desc by size
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     report[fields.FIELD_FORMAT_VERSIONS] = []
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
 
     versions = _format_versions_count_query(
         storage_service_id, start_date, end_date, storage_location_id
@@ -241,12 +229,8 @@ def largest_files(
         report["StorageName"]: Name of Storage Service queried
         report["Files"]: List of result files ordered desc by size
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     report[fields.FIELD_FILES] = []
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
 
     files = _largest_files_query(
         storage_service_id, start_date, end_date, storage_location_id, file_type, limit
@@ -321,12 +305,8 @@ def largest_aips(
         report["StorageName"]: Name of Storage Service queried
         report["AIPs"]: List of result AIPs ordered desc by size
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     report[fields.FIELD_AIPS] = []
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
 
     aips = _largest_aips_query(
         storage_service_id, start_date, end_date, storage_location_id, limit
@@ -417,12 +397,7 @@ def _aips_by_file_format_or_puid(
         report["StorageName"]: Name of Storage Service queried
         report["AIPs"]: List of result AIPs ordered desc by count
     """
-    report = {}
-
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
+    report = report_dict(storage_service_id, storage_location_id)
 
     if file_format:
         report[fields.FIELD_FORMAT] = search_string
@@ -513,22 +488,15 @@ def agents_transfers(
         report["StorageLocation"]: Name of storage location, if applicable
         report["Ingest"]: List of ingest event dictionaries
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
+
     ingests = []
 
-    storage_service_name = get_storage_service_name(storage_service_id)
-    if not storage_service_name:
+    if not report[fields.FIELD_STORAGE_NAME]:
         # No storage service has been returned and so we have nothing
         # to return.
-        report[fields.FIELD_STORAGE_NAME] = None
-        report[fields.FIELD_STORAGE_LOCATION] = None
         report[fields.FIELD_INGESTS] = ingests
         return report
-
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
 
     aips = (
         AIP.query.filter_by(storage_service_id=storage_service_id)
@@ -606,12 +574,8 @@ def preservation_derivatives(
         report["StorageName"]: Name of Storage Service queried
         report["Files"]: List of result files ordered desc by size
     """
-    report = {}
+    report = report_dict(storage_service_id, storage_location_id)
     report[fields.FIELD_FILES] = []
-    report[fields.FIELD_STORAGE_NAME] = get_storage_service_name(storage_service_id)
-    report[fields.FIELD_STORAGE_LOCATION] = get_storage_location_description(
-        storage_location_id
-    )
 
     files = _preservation_derivatives_query(
         storage_service_id, storage_location_id, aip_uuid

--- a/AIPscan/Data/report_data_typesense.py
+++ b/AIPscan/Data/report_data_typesense.py
@@ -1,0 +1,276 @@
+from AIPscan import typesense_helpers as ts_helpers
+from AIPscan.Data import fields, report_dict
+
+
+def document_to_report_row(document, report_fields):
+    row = {}
+
+    for report_field in report_fields:
+        document_field = report_fields[report_field]
+
+        if document_field == "size":
+            row[report_field] = int(document.get(document_field, 0))
+        else:
+            row[report_field] = document.get(document_field, "")
+
+    return row
+
+
+def formats_count(
+    storage_service_id,
+    storage_location_id,
+    start_date,
+    end_date,
+    include_size_data=True,
+):
+    report = report_dict(storage_service_id, storage_location_id)
+    report[fields.FIELD_FORMATS] = []
+
+    # Get format counts via facet data
+    file_filters = ts_helpers.file_filters(
+        storage_service_id, storage_location_id, start_date, end_date
+    )
+
+    results = ts_helpers.search(
+        "file",
+        {
+            "q": "*",
+            "filter_by": ts_helpers.assemble_filter_by(file_filters),
+            "exclude_fields": "*",
+            "facet_by": "file_format",
+            "max_facet_values": 10000,
+        },
+    )
+
+    value_counts = ts_helpers.facet_value_counts(results, "file_format")
+
+    format_size_sums = {}
+    if include_size_data:
+        # Request total size of files for each file format
+        search_requests = {"searches": []}
+        for file_format in value_counts.keys():
+            format_filters = file_filters.copy()
+            format_filters.append(("file_format", "=", f"`{file_format}`"))
+
+            format_filter_by = ts_helpers.assemble_filter_by(format_filters)
+
+            search_requests["searches"].append(
+                {
+                    "collection": ts_helpers.collection_prefix("file"),
+                    "q": "*",
+                    "include_fields": "file_format",
+                    "filter_by": format_filter_by,
+                    "facet_by": "size",
+                    "max_facet_values": 1,
+                }
+            )
+
+        searches = ts_helpers.client().multi_search.perform(
+            search_requests, {"limit_multi_searches": len(search_requests["searches"])}
+        )
+
+        # Summarize file format sizes
+        for results in searches["results"]:
+            if "hits" in results:
+                file_format = results["hits"][0]["document"]["file_format"]
+
+                for count in results["facet_counts"]:
+                    if count["field_name"] == "size":
+                        format_size_sums[file_format] = count["stats"]["sum"]
+
+    # Format results for report
+    format_data = {}
+
+    for file_format in value_counts.keys():
+        format_data[file_format] = {
+            fields.FIELD_FORMAT: file_format,
+            fields.FIELD_COUNT: value_counts[file_format],
+        }
+
+        if format_size_sums != {}:
+            format_data[file_format][fields.FIELD_SIZE] = format_size_sums.get(
+                file_format, 0
+            )
+
+    report[fields.FIELD_FORMATS] = list(format_data.values())
+
+    return report
+
+
+def largest_aips(
+    storage_service_id, start_date, end_date, storage_location_id, limit=20
+):
+    report = report_dict(storage_service_id, storage_location_id)
+    report[fields.FIELD_AIPS] = []
+
+    # Assemble filter_by
+    start_timestamp = ts_helpers.datetime_to_timestamp_int(start_date)
+    end_timestamp = ts_helpers.datetime_to_timestamp_int(end_date)
+
+    filters = [
+        ("create_date", ">=", start_timestamp),
+        ("create_date", "<", end_timestamp),
+        ("storage_service_id", "=", storage_service_id),
+    ]
+
+    if storage_location_id is not None and storage_location_id != "":
+        filters.append(("storage_location_id", "=", storage_location_id))
+
+    filter_by = ts_helpers.assemble_filter_by(filters)
+
+    # Get AIPs in descending order of size
+    report_fields = {
+        fields.FIELD_UUID: "uuid",
+        fields.FIELD_NAME: "transfer_name",
+        fields.FIELD_SIZE: "size",
+        fields.FIELD_FILE_COUNT: "original_file_count",
+    }
+
+    results = ts_helpers.search(
+        "aip",
+        {
+            "q": "*",
+            "filter_by": filter_by,
+            "include_fields": ",".join(list(report_fields.values())),
+            "per_page": limit,
+            "sort_by": "size:desc",
+        },
+    )
+
+    # Format results for report
+    for hit in results["hits"]:
+        file_info = document_to_report_row(hit["document"], report_fields)
+        report[fields.FIELD_AIPS].append(file_info)
+
+    return report
+
+
+def largest_files(
+    storage_service_id,
+    start_date,
+    end_date,
+    storage_location_id,
+    file_type=None,
+    limit=20,
+):
+    report = report_dict(storage_service_id, storage_location_id)
+    report[fields.FIELD_FILES] = []
+
+    # Get files in descending order of size
+    file_filters = ts_helpers.file_filters(
+        storage_service_id, storage_location_id, start_date, end_date
+    )
+
+    report_fields = {
+        fields.FIELD_ID: "id",
+        fields.FIELD_UUID: "uuid",
+        fields.FIELD_NAME: "name",
+        fields.FIELD_SIZE: "size",
+        fields.FIELD_FILE_TYPE: "file_type",
+        fields.FIELD_FORMAT: "file_format",
+        fields.FIELD_VERSION: "format_version",
+        fields.FIELD_PUID: "puid",
+        fields.FIELD_AIP_NAME: "transfer_name",
+        fields.FIELD_AIP_UUID: "aip_uuid",
+    }
+
+    results = ts_helpers.search(
+        "file",
+        {
+            "q": "*",
+            "filter_by": ts_helpers.assemble_filter_by(file_filters),
+            "include_fields": ",".join(list(report_fields.values())),
+            "per_page": limit,
+            "sort_by": "size:desc",
+        },
+    )
+
+    # Format results for report
+    for hit in results["hits"]:
+        file_info = document_to_report_row(hit["document"], report_fields)
+        report[fields.FIELD_FILES].append(file_info)
+
+    return report
+
+
+def format_versions_count(
+    storage_service_id, start_date, end_date, storage_location_id=None
+):
+    report = report_dict(storage_service_id, storage_location_id)
+    report[fields.FIELD_FORMAT_VERSIONS] = []
+
+    # Get format counts via facet data
+    file_filters = ts_helpers.file_filters(
+        storage_service_id, storage_location_id, start_date, end_date
+    )
+
+    results = ts_helpers.search(
+        "file",
+        {
+            "q": "*",
+            "filter_by": ts_helpers.assemble_filter_by(file_filters),
+            "include_fields": "puid",
+            "facet_by": "puid",
+            "max_facet_values": 10000,
+        },
+    )
+
+    puid_counts = ts_helpers.facet_value_counts(results, "puid")
+    puids = list(puid_counts.keys())
+
+    # Request total size of files for each PUID
+    search_requests = {"searches": []}
+    for puid in puids:
+        format_filters = file_filters.copy()
+        format_filters.append(("puid", "=", f"`{puid}`"))
+
+        format_filter_by = ts_helpers.assemble_filter_by(format_filters)
+
+        search_requests["searches"].append(
+            {
+                "collection": ts_helpers.collection_prefix("file"),
+                "q": "*",
+                "include_fields": "puid,file_format,format_version",
+                "filter_by": format_filter_by,
+                "facet_by": "size",
+                "max_facet_values": 1,
+            }
+        )
+
+    searches = ts_helpers.client().multi_search.perform(
+        search_requests, {"limit_multi_searches": len(search_requests["searches"])}
+    )
+
+    # Summarize PUID sizes
+    puid_sizes = {}
+    puid_formats = {}
+    puid_versions = {}
+
+    for results in searches["results"]:
+        document = results["hits"][0]["document"]
+
+        puid = document["puid"]
+        puid_formats[puid] = document["file_format"]
+        puid_versions[puid] = document.get("format_version", "")
+
+        for count in results["facet_counts"]:
+            if count["field_name"] == "size":
+                puid_sizes[puid] = count["stats"]["sum"]
+
+    # Format results for report
+    for puid in puids:
+        version_info = {}
+
+        version_info[fields.FIELD_PUID] = puid
+        version_info[fields.FIELD_FORMAT] = puid_formats[puid]
+        version_info[fields.FIELD_VERSION] = puid_versions.get("puid", "")
+        version_info[fields.FIELD_COUNT] = puid_counts[puid]
+
+        version_info[fields.FIELD_SIZE] = 0
+
+        if puid_sizes[puid] is not None:
+            version_info[fields.FIELD_SIZE] = puid_sizes[puid]
+
+        report[fields.FIELD_FORMAT_VERSIONS].append(version_info)
+
+    return report

--- a/AIPscan/Reporter/report_format_versions_count.py
+++ b/AIPscan/Reporter/report_format_versions_count.py
@@ -2,7 +2,8 @@
 
 from flask import render_template, request
 
-from AIPscan.Data import fields, report_data
+from AIPscan import typesense_helpers as ts_helpers
+from AIPscan.Data import fields, report_data, report_data_typesense
 from AIPscan.helpers import parse_bool, parse_datetime_bound
 from AIPscan.Reporter import (
     download_csv,
@@ -33,12 +34,21 @@ def report_format_versions_count():
     )
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    version_data = report_data.format_versions_count(
-        storage_service_id=storage_service_id,
-        start_date=start_date,
-        end_date=end_date,
-        storage_location_id=storage_location_id,
-    )
+    if ts_helpers.typesense_enabled():
+        version_data = report_data_typesense.format_versions_count(
+            storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
+            storage_location_id=storage_location_id,
+        )
+    else:
+        version_data = report_data.format_versions_count(
+            storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
+            storage_location_id=storage_location_id,
+        )
+
     versions = version_data.get(fields.FIELD_FORMAT_VERSIONS)
 
     if csv:

--- a/AIPscan/Reporter/report_largest_aips.py
+++ b/AIPscan/Reporter/report_largest_aips.py
@@ -1,6 +1,7 @@
 from flask import render_template, request
 
-from AIPscan.Data import fields, report_data
+from AIPscan import typesense_helpers as ts_helpers
+from AIPscan.Data import fields, report_data, report_data_typesense
 from AIPscan.helpers import parse_bool, parse_datetime_bound
 from AIPscan.Reporter import (
     download_csv,
@@ -35,13 +36,18 @@ def largest_aips():
         pass
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    aip_data = report_data.largest_aips(
-        storage_service_id=storage_service_id,
-        start_date=start_date,
-        end_date=end_date,
-        storage_location_id=storage_location_id,
-        limit=limit,
-    )
+    if ts_helpers.typesense_enabled():
+        aip_data = report_data_typesense.largest_aips(
+            storage_service_id, start_date, end_date, storage_location_id, limit
+        )
+    else:
+        aip_data = report_data.largest_aips(
+            storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
+            storage_location_id=storage_location_id,
+            limit=limit,
+        )
 
     if csv:
         headers = translate_headers(HEADERS, True)

--- a/AIPscan/Reporter/report_largest_files.py
+++ b/AIPscan/Reporter/report_largest_files.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-
 from flask import render_template, request
 
-from AIPscan.Data import fields, report_data
+from AIPscan import typesense_helpers as ts_helpers
+from AIPscan.Data import fields, report_data, report_data_typesense
 from AIPscan.helpers import parse_bool, parse_datetime_bound
 from AIPscan.Reporter import (
     download_csv,
@@ -52,14 +52,24 @@ def largest_files():
         pass
     csv = parse_bool(request.args.get(request_params.CSV), default=False)
 
-    file_data = report_data.largest_files(
-        storage_service_id=storage_service_id,
-        start_date=start_date,
-        end_date=end_date,
-        storage_location_id=storage_location_id,
-        file_type=file_type,
-        limit=limit,
-    )
+    if ts_helpers.typesense_enabled():
+        file_data = report_data_typesense.largest_files(
+            storage_service_id,
+            start_date,
+            end_date,
+            storage_location_id,
+            file_type,
+            limit,
+        )
+    else:
+        file_data = report_data.largest_files(
+            storage_service_id=storage_service_id,
+            start_date=start_date,
+            end_date=end_date,
+            storage_location_id=storage_location_id,
+            file_type=file_type,
+            limit=limit,
+        )
 
     if csv:
         headers = translate_headers(CSV_HEADERS, True)

--- a/AIPscan/Reporter/tests/test_formats_count.py
+++ b/AIPscan/Reporter/tests/test_formats_count.py
@@ -1,12 +1,80 @@
-from flask import current_app
+import pytest
+from flask import current_app, url_for
+
+from AIPscan import typesense_test_helpers
 
 EXPECTED_CSV_CONTENTS = b"Format,Count,Size,Size (bytes)\r\nJPEG,2,3.0 kB,3000\r\nISO Disk Image File,1,0 Bytes,0\r\n"
 
 
-def test_formats_count(app_with_populated_format_versions):
+@pytest.mark.parametrize(
+    "view, url_params",
+    [
+        ("reporter.report_formats_count", {"amss_id": "1"}),
+        (
+            "reporter.chart_formats_count",
+            {
+                "start_date": "2019-01-30",
+                "end_date": "2024-02-26",
+                "amss_id": 1,
+                "storage_location": "",
+            },
+        ),
+        (
+            "reporter.plot_formats_count",
+            {
+                "start_date": "2019-01-30",
+                "end_date": "2024-02-26",
+                "amss_id": "1",
+                "storage_location": "",
+            },
+        ),
+    ],
+)
+def test_formats_count_reports(app_with_populated_format_versions, view, url_params):
     """Test that report template renders."""
+    with current_app.test_request_context():
+        url_path_and_params = url_for(view, **url_params)
+
     with current_app.test_client() as test_client:
-        response = test_client.get("/reporter/report_formats_count/?amss_id=1")
+        response = test_client.get(url_path_and_params)
+        assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "view, url_params",
+    [
+        ("reporter.report_formats_count", {"amss_id": 1}),
+        (
+            "reporter.chart_formats_count",
+            {
+                "start_date": "2019-01-30",
+                "end_date": "2024-02-26",
+                "amss_id": "1",
+                "storage_location": "",
+            },
+        ),
+        (
+            "reporter.plot_formats_count",
+            {
+                "start_date": "2019-01-30",
+                "end_date": "2024-02-26",
+                "amss_id": "1",
+                "storage_location": "",
+            },
+        ),
+    ],
+)
+def test_formats_count_reports_using_typesense(
+    app_with_populated_format_versions, enable_typesense, mocker, view, url_params
+):
+    """Test that report template renders."""
+    with current_app.test_request_context():
+        url_path_and_params = url_for(view, **url_params)
+
+    with current_app.test_client() as test_client:
+        typesense_test_helpers.fake_collection_format_counts(mocker)
+
+        response = test_client.get(url_path_and_params)
         assert response.status_code == 200
 
 

--- a/AIPscan/conftest.py
+++ b/AIPscan/conftest.py
@@ -5,6 +5,7 @@ import uuid
 from datetime import datetime
 
 import pytest
+from flask import current_app
 
 from AIPscan import create_app, db, test_helpers
 from AIPscan.models import FileType
@@ -604,3 +605,8 @@ def storage_locations(scope="package"):
         yield app
 
         db.drop_all()
+
+
+@pytest.fixture
+def enable_typesense(scope="session"):
+    current_app.config["TYPESENSE_API_KEY"] = "x0x0x0x0x0"

--- a/AIPscan/models.py
+++ b/AIPscan/models.py
@@ -22,6 +22,17 @@ class get_mets_tasks(db.Model):
     status = db.Column(db.String())
 
 
+class index_tasks(db.Model):
+    __bind_key__ = "celery"
+    index_task_id = db.Column(db.String(36), primary_key=True)
+    fetch_job_id = db.Column(
+        db.String(36), db.ForeignKey("fetch_job.id"), nullable=False
+    )
+    indexing_start = db.Column(db.DateTime())
+    indexing_progress = db.Column(db.String(255))
+    indexing_end = db.Column(db.DateTime())
+
+
 class StorageService(db.Model):
     __tablename__ = "storage_service"
     id = db.Column(db.Integer(), primary_key=True)
@@ -257,6 +268,9 @@ class FetchJob(db.Model):
         db.Integer(), db.ForeignKey("storage_service.id"), nullable=False
     )
     aips = db.relationship("AIP", cascade="all,delete", backref="fetch_job", lazy=True)
+    index_tasks = db.relationship(
+        "index_tasks", cascade="all,delete", backref="fetch_job", lazy=True
+    )
 
     def __init__(
         self,

--- a/AIPscan/test_helpers.py
+++ b/AIPscan/test_helpers.py
@@ -1,5 +1,9 @@
+import os
+import time
 import uuid
 from datetime import datetime
+
+import tzlocal
 
 from AIPscan import db
 from AIPscan.models import (
@@ -13,6 +17,7 @@ from AIPscan.models import (
     Pipeline,
     StorageLocation,
     StorageService,
+    index_tasks,
 )
 
 TEST_SHA_256 = "79c16fa9573ec46c5f60fd54b34f314159e0623ca53d8d2f00c5875dbb4e0dfd"
@@ -99,7 +104,7 @@ def create_test_file(**kwargs):
     file_ = File(
         name=kwargs.get("name", "file_name.ext"),
         filepath=kwargs.get("filepath", "/path/to/file_name.ext"),
-        uuid=kwargs.get("uuid", str(uuid.uuid4())),
+        uuid=kwargs.get("uuid", "222222222222-2222-2222-22222222"),
         file_type=kwargs.get("file_type", FileType.original),
         size=kwargs.get("size", 0),
         date_created=kwargs.get("date_created", datetime.now()),
@@ -152,3 +157,23 @@ def create_test_event_agent(**kwargs):
     db.session.execute(event_relationship)
     db.session.commit()
     return event_relationship
+
+
+def create_test_index_tasks(fetch_job_id, task_id):
+    index_task_obj = index_tasks(
+        index_task_id=task_id, fetch_job_id=fetch_job_id, indexing_start=datetime.now()
+    )
+    db.session.add(index_task_obj)
+    db.session.commit()
+
+
+def set_timezone(new_tz):
+    os.environ["TZ"] = new_tz
+    time.tzset()
+
+
+def set_timezone_and_return_current_timezone(new_tz):
+    local_timezone = tzlocal.get_localzone_name()
+    set_timezone(new_tz)
+
+    return local_timezone

--- a/AIPscan/tests/test_typesense_helpers.py
+++ b/AIPscan/tests/test_typesense_helpers.py
@@ -1,0 +1,201 @@
+from datetime import datetime
+
+import typesense
+from pytz import timezone
+
+from AIPscan import test_helpers
+from AIPscan import typesense_helpers as ts_helpers
+from AIPscan import typesense_test_helpers
+from AIPscan.models import File, Pipeline
+
+
+def test_typesense_enabled(app_instance, enable_typesense):
+    assert ts_helpers.typesense_enabled() is True
+
+
+def test_client(app_instance, enable_typesense):
+    client = ts_helpers.client()
+
+    assert type(client) is typesense.Client
+    assert client.config.nodes[0].host == "localhost"
+    assert client.config.nodes[0].port == "8108"
+    assert client.config.nodes[0].protocol == "http"
+    assert client.config.api_key == "x0x0x0x0x0"
+
+
+def test_search(app_instance, enable_typesense, mocker):
+    client = ts_helpers.client()
+
+    search_parameters = {"q": "*"}
+
+    fake_results = {
+        "facet_counts": [],
+        "found": 1,
+        "hits": [{"document": {"aip_id": 1}, "highlight": {}, "highlights": []}],
+        "out_of": 252246,
+        "page": 1,
+        "request_params": {"collection_name": "aipscan_file", "per_page": 10, "q": "*"},
+        "search_cutoff": False,
+        "search_time_ms": 0,
+    }
+
+    fake_collection = typesense_test_helpers.FakeCollection(fake_results)
+
+    query = mocker.patch("typesense.collections.Collections.__getitem__")
+    query.return_value = fake_collection
+
+    results = ts_helpers.search("file", search_parameters, client)
+
+    assert results == fake_results
+
+
+def test_collection_prefix(app_instance):
+    fake_table_name = "test"
+
+    prefixed = ts_helpers.collection_prefix(fake_table_name)
+
+    assert prefixed == f"aipscan_{fake_table_name}"
+
+
+def test_datetime_to_timestamp_int():
+    # Get local time zone then set time zone for testing
+    local_timezone = test_helpers.set_timezone_and_return_current_timezone(
+        "America/Vancouver"
+    )
+
+    # Create time zone object to create datetime objects from
+    pst_tz = timezone("US/Pacific")
+
+    # Test that datetime object gets converted to correct timestamp integer
+    datetime_object = pst_tz.localize(datetime(2019, 1, 30))
+    assert ts_helpers.datetime_to_timestamp_int(datetime_object) == 1548835200
+
+    # Test that datetime object gets rounded to neartest date then converted to timestamp
+    datetime_object = datetime(2019, 1, 30, 2, 30, 50).astimezone(pst_tz)
+    assert ts_helpers.datetime_to_timestamp_int(datetime_object) == 1548835200
+
+    # Reset time zone
+    test_helpers.set_timezone(local_timezone)
+
+
+def test_assemble_filter_by():
+    filters = [("storage_service_id", "=", 1), ("file_type", "=", "'original'")]
+    filter_string = "storage_service_id:=1 && file_type:='original'"
+
+    assert ts_helpers.assemble_filter_by(filters) == filter_string
+
+
+def test_file_filters(app_instance):
+    # Get local time zone then set time zone for testing
+    local_timezone = test_helpers.set_timezone_and_return_current_timezone(
+        "America/Vancouver"
+    )
+
+    file_filters = ts_helpers.file_filters(
+        1, 1, datetime(2019, 1, 1), datetime(2019, 1, 31)
+    )
+
+    desired_filters = [
+        ("date_created", ">=", 1546329600),
+        ("date_created", "<", 1548921600),
+        ("storage_service_id", "=", 1),
+        ("file_type", "=", "'original'"),
+        ("storage_location_id", "=", 1),
+    ]
+
+    assert file_filters == desired_filters
+
+    # Reset time zone
+    test_helpers.set_timezone(local_timezone)
+
+
+def test_facet_value_counts():
+    results = {
+        "facet_counts": [
+            {
+                "field_name": "color",
+                "counts": [{"value": "blue", "count": 9}, {"value": "red", "count": 7}],
+            }
+        ]
+    }
+
+    counts = ts_helpers.facet_value_counts(results)
+
+    assert counts == {"color": {"blue": 9, "red": 7}}
+
+
+def test_get_model_table():
+    assert ts_helpers.get_model_table(File) == "file"
+
+
+def test_collection_fields_from_model():
+    pipeline_fields = [
+        {"name": "id", "type": "int32"},
+        {"name": "origin_pipeline", "type": "string", "optional": True},
+        {"name": "dashboard_url", "type": "string", "optional": True},
+    ]
+
+    assert ts_helpers.collection_fields_from_model(Pipeline) == pipeline_fields
+
+
+def test_initialize_index(app_instance, enable_typesense, mocker):
+    class FakeCollections:
+        def create(self):
+            return True
+
+    fake_collections = FakeCollections()
+    fake_collection = typesense_test_helpers.FakeCollection()
+
+    query = mocker.patch("typesense.collections.Collections.__getitem__")
+    query.return_value = fake_collection
+
+    query2 = mocker.patch("typesense.collections.Collections.create")
+    query2.return_value = fake_collections
+
+    ts_helpers.initialize_index()
+
+
+def test_populate_index(app_instance, enable_typesense, mocker):
+    fake_collection = typesense_test_helpers.FakeCollection()
+
+    query = mocker.patch("typesense.collections.Collections.__getitem__")
+    query.return_value = fake_collection
+
+    ts_helpers.populate_index()
+
+
+def test_augment_file_document_with_aip_data(app_instance):
+    document = {}
+
+    aip_cache = {
+        "original_file_count": {3: 23},
+        "storage_service_id": {3: 1},
+        "storage_location_id": {3: [2]},
+        "create_date": {3: datetime(2024, 3, 2, 5, 35)},
+        "uuid": {3: "111111111111-1111-1111-11111111"},
+        "transfer_name": {3: "Test AIP"},
+    }
+
+    class MockFileResult:
+        id = 4
+        aip_id = 3
+
+    file_result = MockFileResult()
+
+    # Get local time zone then set time zone for testing
+    local_timezone = test_helpers.set_timezone_and_return_current_timezone(
+        "America/Vancouver"
+    )
+
+    ts_helpers.augment_file_document_with_aip_data(
+        "file", document, aip_cache, file_result
+    )
+
+    assert document["storage_service_id"] == 1
+    assert document["storage_location_id"] == [2]
+    assert document["aip_create_date"] == 1709366400
+    assert document["aip_uuid"] == "111111111111-1111-1111-11111111"
+    assert document["transfer_name"] == "Test AIP"
+
+    # Reset time zone
+    test_helpers.set_timezone(local_timezone)

--- a/AIPscan/tests/test_typsense_test_helpers.py
+++ b/AIPscan/tests/test_typsense_test_helpers.py
@@ -1,0 +1,17 @@
+from AIPscan import typesense_test_helpers
+
+FAKE_RESULTS = {"found": 1}
+
+
+def test_fake_documents():
+    fake_documents = typesense_test_helpers.FakeDocuments(FAKE_RESULTS)
+
+    assert fake_documents.fake_results == FAKE_RESULTS
+    assert fake_documents.search({}) == FAKE_RESULTS
+
+
+def test_fake_collection():
+    fake_collection = typesense_test_helpers.FakeCollection(FAKE_RESULTS)
+
+    assert fake_collection.documents.fake_results == FAKE_RESULTS
+    assert fake_collection.documents.search({}) == FAKE_RESULTS

--- a/AIPscan/typesense_helpers.py
+++ b/AIPscan/typesense_helpers.py
@@ -1,0 +1,293 @@
+import datetime
+import math
+import time
+
+import typesense
+from flask import current_app
+from sqlalchemy import inspect
+
+from AIPscan.models import AIP, File, FileType
+
+APP_MODELS = [AIP, File]
+
+FACET_FIELDS = {
+    "file": ["file_format", "file_type", "puid", "aip_id", "size", "aip_create_date"]
+}
+
+AIP_FIELDS_TO_CACHE = {
+    "storage_service_id": None,
+    "storage_location_id": None,
+    "create_date": "aip_create_date",
+    "transfer_name": None,
+    "uuid": "aip_uuid",
+}
+
+
+def typesense_enabled():
+    return current_app.config["TYPESENSE_API_KEY"] is not None
+
+
+def client():
+    config = current_app.config
+    return typesense.Client(
+        {
+            "api_key": config["TYPESENSE_API_KEY"],
+            "nodes": [
+                {
+                    "host": config["TYPESENSE_HOST"],
+                    "port": config["TYPESENSE_PORT"],
+                    "protocol": config["TYPESENSE_PROTOCOL"],
+                }
+            ],
+            "connection_timeout_seconds": int(config["TYPESENSE_TIMEOUT_SECONDS"]),
+        }
+    )
+
+
+def search(collection, search_parameters, ts_client=None):
+    if ts_client is None:
+        ts_client = client()
+
+    return ts_client.collections[collection_prefix(collection)].documents.search(
+        search_parameters
+    )
+
+
+def collection_prefix(collection):
+    return current_app.config["TYPESENSE_COLLECTION_PREFIX"] + collection
+
+
+def datetime_to_timestamp_int(datetime_obj):
+    # Round datetime to date in case time is included
+    datetime_obj = datetime_obj.replace(hour=0, minute=0, second=0)
+
+    return int(time.mktime(datetime_obj.timetuple()))
+
+
+def assemble_filter_by(filters):
+    filter_by = ""
+
+    for clause in filters:
+        if filter_by != "":
+            filter_by += " && "
+
+        filter_by += f"{clause[0]}:{clause[1]}{str(clause[2])}"
+
+    return filter_by
+
+
+def file_filters(storage_service_id, storage_location_id, start_date, end_date):
+    start_timestamp = datetime_to_timestamp_int(start_date)
+    end_timestamp = datetime_to_timestamp_int(end_date)
+
+    filters = [
+        ("date_created", ">=", start_timestamp),
+        ("date_created", "<", end_timestamp),
+        ("storage_service_id", "=", storage_service_id),
+        ("file_type", "=", "'original'"),
+    ]
+
+    if storage_location_id is not None and storage_location_id != "":
+        filters.append(("storage_location_id", "=", storage_location_id))
+
+    return filters
+
+
+def facet_value_counts(result, field_name=None):
+    facet_value_counts = {}
+
+    for facet_count in result["facet_counts"]:
+        facet_value_counts[facet_count["field_name"]] = {}
+
+        for count in facet_count["counts"]:
+            facet_value_counts[facet_count["field_name"]][count["value"]] = count[
+                "count"
+            ]
+
+    if field_name:
+        return facet_value_counts[field_name]
+
+    return facet_value_counts
+
+
+def get_model_table(model):
+    inst = inspect(model)
+    return str(inst.tables[0])
+
+
+def collection_fields_from_model(model):
+    # Reference model definition
+    inst = inspect(model)
+    table = str(inst.tables[0])
+
+    # Define Typesense fields for model
+    fields = []
+
+    for c in inst.columns:
+        field = {"name": c.name}
+
+        # Use Python type as basis of Typesense type
+        if c.type.python_type == FileType:
+            field["type"] = "string"
+        else:
+            ts_types = {
+                int: "int32",
+                str: "string",
+                bool: "bool",
+                datetime.datetime: "int64",
+            }
+
+            # Use larger number type for size data
+            if c.name == "size":
+                ts_types[int] = "int64"
+
+            if c.type.python_type not in ts_types:
+                raise ValueError("Unhandled model column type")
+            else:
+                field["type"] = ts_types[c.type.python_type]
+
+        # Mark certain fields as facets
+        if table in FACET_FIELDS and field["name"] in FACET_FIELDS[table]:
+            field["facet"] = True
+
+        # Mark non-id fields as optional (to accommodate None values)
+        if field["name"] != "id":
+            field["optional"] = True
+
+        fields.append(field)
+
+    # AIP collection documents will be augmented with related data
+    if table == "aip":
+        fields.append({"name": "original_file_count", "type": "int32"})
+
+    # File collection documents will be augmented with related data
+    if table == "file":
+        fields.append({"name": "storage_service_id", "type": "int32"})
+        fields.append({"name": "storage_location_id", "type": "int32"})
+        fields.append({"name": "aip_create_date", "type": "int64", "facet": True})
+        fields.append({"name": "transfer_name", "type": "string"})
+        fields.append({"name": "aip_uuid", "type": "string"})
+
+    return fields
+
+
+def initialize_index():
+    ts_client = client()
+
+    # Create Typesense collections containing data for each model
+    for model in APP_MODELS:
+        table = get_model_table(model)
+
+        # Delete collection if it exists
+        try:
+            ts_client.collections[collection_prefix(table)].delete()
+        except typesense.exceptions.ObjectNotFound:
+            pass
+
+        # Create collection
+        fields = collection_fields_from_model(model)
+
+        ts_client.collections.create(
+            {"name": collection_prefix(table), "fields": fields}
+        )
+
+
+def model_instance_to_document(model, instance, model_fields=None):
+    if model_fields is None:
+        model_fields = collection_fields_from_model(model)
+
+    document = {}
+
+    for field in model_fields:
+        if hasattr(instance, field["name"]):
+            value = getattr(instance, field["name"])
+
+            # Typesense IDs need to be strings
+            if field["name"] == "id":
+                value = str(value)
+
+            if isinstance(value, datetime.datetime):
+                value = int(value.timestamp())
+
+            if isinstance(value, FileType):
+                value = str(value).replace("FileType.", "")
+
+            if value is not None:
+                document[field["name"]] = value
+
+    return document
+
+
+def augment_file_document_with_aip_data(table, document, aip_cache, result):
+    for aip_field in AIP_FIELDS_TO_CACHE:
+        if aip_field != "create_date":
+            if AIP_FIELDS_TO_CACHE[aip_field] is None:
+                document[aip_field] = aip_cache[aip_field][result.aip_id]
+            else:
+                document_field = AIP_FIELDS_TO_CACHE[aip_field]
+                document[document_field] = aip_cache[aip_field][result.aip_id]
+
+    # Round AIP create date to the day
+    dt = aip_cache["create_date"][result.aip_id]
+    dt = datetime.datetime(*dt.timetuple()[0:3])
+    document["aip_create_date"] = int(dt.strftime("%s"))
+
+
+def populate_index():
+    ts_client = client()
+
+    # Initialize AIP cache
+    aip_cache = {}
+    for aip_field in AIP_FIELDS_TO_CACHE:
+        aip_cache[aip_field] = {}
+
+    # Add documents to collections
+    for model in APP_MODELS:
+        table = get_model_table(model)
+        model_fields = collection_fields_from_model(model)
+
+        results = model.query.all()
+
+        docs = []
+        indexed = 0
+        completed_percent = 0
+
+        for result in results:
+            document = model_instance_to_document(model, result, model_fields)
+
+            if model is File:
+                augment_file_document_with_aip_data(table, document, aip_cache, result)
+
+            docs.append(document)
+            perform_bulk_document_creation(ts_client, table, docs)
+
+            indexed += 1
+            completed_percent = math.ceil(indexed / len(results) * 100)
+
+            status = {
+                "type": model.__name__,
+                "indexed": indexed,
+                "total": len(results),
+                "percent": completed_percent,
+            }
+
+            if model == AIP:
+                for aip_field in AIP_FIELDS_TO_CACHE:
+                    aip_cache[aip_field][result.id] = getattr(result, aip_field)
+
+            yield status
+
+        finish_bulk_document_creation(ts_client, table, docs)
+
+
+def perform_bulk_document_creation(ts_client, table, docs):
+    # Send bulk creation every 40 documents
+    if len(docs) == 40:
+        ts_client.collections[collection_prefix(table)].documents.import_(docs)
+        docs = []
+
+
+def finish_bulk_document_creation(ts_client, table, docs):
+    # Send bulk creation of remaining documents
+    if len(docs):
+        ts_client.collections[collection_prefix(table)].documents.import_(docs)

--- a/AIPscan/typesense_test_helpers.py
+++ b/AIPscan/typesense_test_helpers.py
@@ -1,0 +1,53 @@
+FAKE_RESULTS_FORMAT_COUNTS = {
+    "facet_counts": [
+        {"field_name": "file_format", "counts": [{"value": "wav", "count": 10}]}
+    ]
+}
+
+
+FAKE_MULTI_SEARCH_RESULTS_FORMAT_COUNTS = {
+    "results": [
+        {
+            "hits": [{"document": {"file_format": "wav"}}],
+            "facet_counts": [{"field_name": "size", "stats": {"sum": 999}}],
+        }
+    ]
+}
+
+
+def fake_collection_format_counts(mocker):
+    fake_collection = FakeCollection(FAKE_RESULTS_FORMAT_COUNTS)
+
+    query_collection = mocker.patch("typesense.collections.Collections.__getitem__")
+    query_collection.return_value = fake_collection
+
+    query_multi = mocker.patch("typesense.multi_search.MultiSearch.perform")
+    query_multi.return_value = FAKE_MULTI_SEARCH_RESULTS_FORMAT_COUNTS
+
+    return fake_collection
+
+
+def fake_collection(mocker, fake_results):
+    fake_collection = FakeCollection(fake_results)
+
+    query = mocker.patch("typesense.collections.Collections.__getitem__")
+    query.return_value = fake_collection
+
+
+class FakeDocuments:
+    def __init__(self, fake_results):
+        self.fake_results = fake_results
+
+    def search(self, search_parameters):
+        return self.fake_results
+
+    def _import(self, search_parameters):
+        return {}
+
+
+class FakeCollection:
+    def __init__(self, fake_results=None):
+        self.documents = FakeDocuments(fake_results)
+
+    def delete(self):
+        return

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,6 +64,21 @@ systems and servers have not been tested.
    sudo service rabbitmq-server stop
    ```
 
+## Typesense (optional)
+
+Typesense doesn't yet exist in major Linux distribution package repositories and
+has to be installed manually.
+
+Official installation instructions are available for [Ubuntu][1] and [Centos/RHEL][2].
+
+[1]: https://typesense.org/docs/guide/install-typesense.html#deb-package-on-ubuntu-debian
+
+[2]: https://typesense.org/docs/guide/install-typesense.html#rpm-package-on-centos-rhel
+
+After installing Typesense the API key, needed to enable Typesense
+functionality in AIPscan, can be found in the
+`/etc/typesense/typesense-server.ini` file.
+
 ## Gunicorn service
 
 * Create the following service file for Gunicorn:
@@ -92,6 +107,13 @@ RestartSec=30
 
 [Install]
 WantedBy=multi-user.target
+```
+
+If you wish to use Typesense with AIPscan, you'll need to define an environment variable
+in the `[Service]` section of this file. For example:
+
+```bash
+Environment="TYPESENSE_API_KEY=1234"
 ```
 
 * Start the new AIPscan Gunicorn service:
@@ -214,6 +236,13 @@ RestartSec=30
 
 [Install]
 WantedBy=multi-user.target
+```
+
+If you wish to use Typesense with AIPscan, you'll need to define an environment variable
+in the `[Service]` section of this file. For example:
+
+```bash
+Environment="TYPESENSE_API_KEY=1234"
 ```
 
 * Start the Celery service:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,44 @@ AIPscan report.
 
 ![screencap5](screencaps/aipscan_hello_world.png)
 
+### Typesense integration
+
+AIPscan can optionally be run using Typesense as a report data source,
+potentially reducing the time to generate reports. If Typesense is installed
+and enabled then AIPscan data will be automatically indexed after each fetch
+job and report queries will pull data from Typesense rather than the
+application's database.
+
+Typesense can be installed a variety of ways
+[detailed on their website](https://typesense.org/docs/guide/install-typesense.html).
+
+#### Configuration
+
+Typesense configuration is done using the following environment variables:
+
+* Typesense API key (required): `TYPESENSE_API_KEY`
+* Typesense host: `TYPESENSE_HOST` (default "localhost")
+* Typesense port: `TYPESENSE_PORT` (default "8108")
+* Typesense URL protocol: `TYPESENSE_PROTOCOL` (default "http")
+* Typesense timeout (in seconds): `TYPESENSE_TIMEOUT_SECONDS` (default "30")
+* Typesense collection prefix: `TYPESENSE_COLLECTION_PREFIX` (default "aipscan_")
+
+Typesense support is enabled by the setting of `TYPESENSE_API_KEY`.
+
+Here's an example:
+
+  ```bash
+  TYPESENSE_API_KEY="xOxOxOxO" python run.py
+  ```
+
+#### Related CLI tools
+
+Two CLI tools exist to manually indexed AIPscan's database and to see a
+summary of the Typesense index.
+
+* Index AIPscan data: `tools/index-refresh`
+* Display a summary of the Typesense index: `tools/index-summary`
+
 ## Background workers
 
 Crawling and parsing many Archivematica AIP METS xml files at a time is

--- a/config.py
+++ b/config.py
@@ -7,6 +7,13 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 DEFAULT_AIPSCAN_DB = "sqlite:///" + os.path.join(basedir, "aipscan.db")
 DEFAULT_CELERY_DB = "sqlite:///" + os.path.join(basedir, "celerytasks.db")
 
+DEFAULT_TYPESENSE_HOST = "localhost"
+DEFAULT_TYPESENSE_PORT = "8108"
+DEFAULT_TYPESENSE_API_KEY = None
+DEFAULT_TYPESENSE_PROTOCOL = "http"
+DEFAULT_TYPESENSE_TIMEOUT_SECONDS = "30"
+DEFAULT_TYPESENSE_COLLECTION_PREFIX = "aipscan_"
+
 
 class Config:
     # Be sure to set a secure secret key for production.
@@ -22,6 +29,17 @@ class Config:
     SQLALCHEMY_BINDS = {"celery": SQLALCHEMY_CELERY_BACKEND}
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False
+
+    TYPESENSE_HOST = os.getenv("TYPESENSE_HOST", DEFAULT_TYPESENSE_HOST)
+    TYPESENSE_PORT = os.getenv("TYPESENSE_PORT", DEFAULT_TYPESENSE_PORT)
+    TYPESENSE_API_KEY = os.getenv("TYPESENSE_API_KEY", DEFAULT_TYPESENSE_API_KEY)
+    TYPESENSE_PROTOCOL = os.getenv("TYPESENSE_PROTOCOL", DEFAULT_TYPESENSE_PROTOCOL)
+    TYPESENSE_TIMEOUT_SECONDS = os.getenv(
+        "TYPESENSE_TIMEOUT_SECONDS", DEFAULT_TYPESENSE_TIMEOUT_SECONDS
+    )
+    TYPESENSE_COLLECTION_PREFIX = os.getenv(
+        "TYPESENSE_COLLECTION_PREFIX", DEFAULT_TYPESENSE_COLLECTION_PREFIX
+    )
 
 
 class DevelopmentConfig(Config):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
 volumes:
   rabbitmq_data:
   rabbitmq_logs:
+  typesense_data:
 
 services:
   aipscan:
     build: ./
     environment:
       - CELERY_BROKER_URL=amqp://guest@rabbitmq//
+      - TYPESENSE_HOST=typesense
+      - TYPESENSE_API_KEY=xyz
     ports:
       - 5000:5000
     volumes:
@@ -28,9 +31,21 @@ services:
     build: ./
     environment:
       - CELERY_BROKER_URL=amqp://guest@rabbitmq//
-    command: celery worker -A AIPscan.worker.celery --loglevel=info
+      - TYPESENSE_HOST=typesense
+      - TYPESENSE_API_KEY=xyz
+    command: celery -A AIPscan.worker.celery worker --loglevel=info
     volumes:
       - "./:/src:rw"
     depends_on:
       - rabbitmq
       - aipscan
+
+  typesense:
+    image: typesense/typesense:0.26.0.rc23
+    environment:
+      TYPESENSE_DATA_DIR: /data
+      TYPESENSE_API_KEY: xyz
+    volumes:
+      - typesense_data:/data
+    ports:
+      - 8108:8108

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -35,3 +35,4 @@ vine==5.0.0
 Werkzeug== 3.0.2
 WTForms==2.3.3
 zipp==3.18.1
+typesense==0.19.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,9 @@
 -r base.txt
 
+faker==14.2.1
 flake8==5.0.4
 flake8-builtins==2.2.0
 pytest==6.2.5
 pytest_cov==2.11.1
 pytest_mock==3.3.1
+tzlocal==5.2

--- a/tools/index-refresh
+++ b/tools/index-refresh
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import sys
+
+from app import cli
+
+from AIPscan import db, typesense_helpers
+from config import CONFIGS
+
+
+def main():
+    # Initialize Flask app context
+    app = cli.create_app_instance(CONFIGS[cli.config_name], db)
+
+    with app.app_context():
+        if not typesense_helpers.typesense_enabled():
+            sys.exit("Error: Typesense not enabled in AIPscan.")
+
+        print("Initializing index...")
+        typesense_helpers.initialize_index()
+
+        print("Caching AIP data...")
+
+        completed_percent = None
+        for status in typesense_helpers.populate_index():
+            # Print update when percentage indexed (to nearest integer) has changed
+            if completed_percent != status["percent"]:
+                print(f"Indexing {status['type']} data ({status['percent']}%)")
+                completed_percent = status["percent"]
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/index-summary
+++ b/tools/index-summary
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+import sys
+
+from app import cli
+
+from AIPscan import db, typesense_helpers
+from config import CONFIGS
+
+
+def main():
+    # Initialize Flask app context
+    app = cli.create_app_instance(CONFIGS[cli.config_name], db)
+
+    with app.app_context():
+        if not typesense_helpers.typesense_enabled():
+            sys.exit("Error: Typesense not enabled in AIPscan.")
+
+        client = typesense_helpers.client()
+
+        for model in typesense_helpers.APP_MODELS:
+            table = typesense_helpers.get_model_table(model)
+            collection = typesense_helpers.collection_prefix(table)
+            result = client.collections[collection].retrieve()
+
+            print(f"Name: {result['name']}")
+            print(f"* Fields: {len(result['fields'])}")
+            print(f"* Documents: {result['num_documents']}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
* Added test helpers for changing the time zone during tests
* Added Typesense helpers and Typesense testing functions
* Added CLI tools for indexing the AIPscan database in Typesense and
  for outputting a summary of indexed data
* Added Typesense indexing Celery task and integrated it with fetch job
* Added Typesense-specific report data providers for formats counts,
  format versions, largest AIPs, and largest files reports
* Created report_dict function and uses in various reports
* Cleaned up fetch job-related Javascript