### PR TITLE
Update Black version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/ambv/black
-  rev: 18.9b0
+  rev: 24.3.0
   hooks:
   - id: black
     args: [--safe, --quiet]

--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -193,12 +193,14 @@ def workflow_coordinator(
         fetch_job_id, all_packages, total_packages_count
     )
 
-    summary = "aips: '{}'; sips: '{}'; dips: '{}'; deleted: '{}'; replicated: '{}'".format(
-        obj.total_aips,
-        obj.total_sips,
-        obj.total_dips,
-        obj.total_deleted_aips,
-        obj.total_replicas,
+    summary = (
+        "aips: '{}'; sips: '{}'; dips: '{}'; deleted: '{}'; replicated: '{}'".format(
+            obj.total_aips,
+            obj.total_sips,
+            obj.total_dips,
+            obj.total_deleted_aips,
+            obj.total_replicas,
+        )
     )
     logger.info("%s", summary)
 

--- a/AIPscan/Data/data.py
+++ b/AIPscan/Data/data.py
@@ -190,9 +190,9 @@ def derivative_overview(storage_service_id, storage_location_id=None):
                 continue
 
             file_derivative_pair = {}
-            file_derivative_pair[
-                fields.FIELD_DERIVATIVE_UUID
-            ] = preservation_derivative.uuid
+            file_derivative_pair[fields.FIELD_DERIVATIVE_UUID] = (
+                preservation_derivative.uuid
+            )
             file_derivative_pair[fields.FIELD_ORIGINAL_UUID] = original_file.uuid
             original_format_version = original_file.format_version
             if original_format_version is None:


### PR DESCRIPTION
The Black version in pre-commit config is out of date making linting fail when using a recent version.