### PR TITLE
Fix format-related Typesense report errors (#342)

### DIFF
--- a/AIPscan/Data/report_data_typesense.py
+++ b/AIPscan/Data/report_data_typesense.py
@@ -44,6 +44,10 @@ def formats_count(
 
     value_counts = ts_helpers.facet_value_counts(results, "file_format")
 
+    # If no formats were found then don't proceed to get counts
+    if len(value_counts) == 0:
+        return report
+
     format_size_sums = {}
     if include_size_data:
         # Request total size of files for each file format
@@ -216,9 +220,14 @@ def format_versions_count(
     )
 
     puid_counts = ts_helpers.facet_value_counts(results, "puid")
-    puids = list(puid_counts.keys())
+
+    # If no format versions were found then don't proceed to get counts
+    if len(puid_counts) == 0:
+        return report
 
     # Request total size of files for each PUID
+    puids = list(puid_counts.keys())
+
     search_requests = {"searches": []}
     for puid in puids:
         format_filters = file_filters.copy()

--- a/AIPscan/Data/tests/test_format_versions_count.py
+++ b/AIPscan/Data/tests/test_format_versions_count.py
@@ -7,7 +7,7 @@ import pytest
 from AIPscan.conftest import AIP_1_CREATION_DATE, AIP_2_CREATION_DATE
 from AIPscan.conftest import ORIGINAL_FILE_SIZE as JPEG_1_01_FILE_SIZE
 from AIPscan.conftest import PRESERVATION_FILE_SIZE as JPEG_1_02_FILE_SIZE
-from AIPscan.Data import fields, report_data
+from AIPscan.Data import fields, report_data, report_data_typesense
 from AIPscan.Data.tests import (
     MOCK_STORAGE_SERVICE,
     MOCK_STORAGE_SERVICE_ID,
@@ -185,3 +185,29 @@ def test_format_versions_count_contents(
         sum(version.get(fields.FIELD_SIZE, 0) for version in versions)
         == total_file_size
     )
+
+
+def test_format_versions_count_no_results_typesense(
+    app_with_populated_files, enable_typesense, mocker
+):
+
+    mocker.patch("typesense.collections.Collections.__getitem__")
+    mocker.patch("typesense.multi_search.MultiSearch.perform")
+    mocker.patch("AIPscan.typesense_helpers.facet_value_counts")
+
+    expected_result = {
+        "StorageName": "test storage service",
+        "StorageLocation": "test storage location",
+        "FormatVersions": [],
+    }
+
+    start_date = "2019-01-01"
+    end_date = "2019-10-01"
+
+    report = report_data_typesense.format_versions_count(
+        1,
+        datetime.strptime(start_date, "%Y-%m-%d"),
+        datetime.strptime(end_date, "%Y-%m-%d"),
+        1,
+    )
+    assert report == expected_result

--- a/AIPscan/Data/tests/test_formats_count.py
+++ b/AIPscan/Data/tests/test_formats_count.py
@@ -78,6 +78,31 @@ def test_formats_count(app_instance, mocker, query_results, results_count):
     assert len(report[fields.FIELD_FORMATS]) == results_count
 
 
+def test_formats_count_no_results_typesense(
+    app_with_populated_files, enable_typesense, mocker
+):
+    mocker.patch("typesense.collections.Collections.__getitem__")
+    mocker.patch("typesense.multi_search.MultiSearch.perform")
+    mocker.patch("AIPscan.typesense_helpers.facet_value_counts")
+
+    expected_result = {
+        "StorageName": "test storage service",
+        "StorageLocation": "test storage location",
+        "Formats": [],
+    }
+
+    start_date = "2019-01-01"
+    end_date = "2019-10-01"
+
+    report = report_data_typesense.formats_count(
+        1,
+        1,
+        datetime.strptime(start_date, "%Y-%m-%d"),
+        datetime.strptime(end_date, "%Y-%m-%d"),
+    )
+    assert report == expected_result
+
+
 def test_formats_count_typesense(app_with_populated_files, enable_typesense, mocker):
     typesense_test_helpers.fake_collection_format_counts(mocker)
 


### PR DESCRIPTION
Don't bother doing a counts of formats, and format versions, of files matching report criteria if no formats, or format versions, were found (given that otherwise a multi-search Typesense query will be sent with no searches and will result in an HTTP 500 error).
