### PR TITLE
Bump jinja2 from 3.1.4 to 3.1.5 in /requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ gunicorn==22.0.0
 idna==3.7
 importlib-metadata==3.6.0
 itsdangerous==2.0.1
-jinja2==3.1.4
+jinja2==3.1.5
 kombu==5.2.2
 lxml==4.9.1
 MarkupSafe==2.1.1


### PR DESCRIPTION
Fix security issues:

* https://github.com/artefactual-labs/AIPscan/security/dependabot/46
* https://github.com/artefactual-labs/AIPscan/security/dependabot/47