### PR TITLE
Use gunicorn preload option in install guide

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,7 +99,7 @@ User=archivematica
 Group=archivematica
 WorkingDirectory=/usr/share/archivematica/AIPscan
 Environment="PYTHONUNBUFFERED=1"
-ExecStart=/usr/share/archivematica/virtualenvs/AIPscan/bin/gunicorn --workers 3 --bind unix:aipscan.sock "AIPscan:create_app()"
+ExecStart=/usr/share/archivematica/virtualenvs/AIPscan/bin/gunicorn --preload --workers 3 --bind unix:aipscan.sock "AIPscan:create_app()"
 ExecReload=/bin/kill -s HUP $MAINPID
 ExecStop=/bin/kill -s TERM $MAINPID
 PrivateTmp=true


### PR DESCRIPTION
Starting gunicorn with the preload option makes it easier to diagnose issues and lessens memory usage.