### PR TITLE
Replace Python 3.8 support with 3.11/3.12 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.8"
-            toxenv: "py38"
           - python-version: "3.9"
             toxenv: "py39"
           - python-version: "3.10"
             toxenv: "py310"
+          - python-version: "3.11"
+            toxenv: "py311"
+          - python-version: "3.12"
+            toxenv: "py312"
     steps:
       - name: "Check out repository"
         uses: "actions/checkout@v3"

--- a/AIPscan/helpers.py
+++ b/AIPscan/helpers.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 import hashlib
 from datetime import datetime, timedelta
-from distutils.util import strtobool
 
 
-def parse_bool(val, default=True):
-    try:
-        return bool(strtobool(val))
-    except (ValueError, AttributeError):
-        return default
+def parse_bool(value, default=True):
+    if value is not None:
+        value = value.lower()
+
+        if value in ("y", "yes", "on", "1", "true", "t"):
+            return True
+
+    return False
 
 
 def parse_datetime_bound(date_string, upper=False):

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,10 +1,10 @@
-amqp==5.0.9
-billiard==3.6.4
-celery==5.2.2
+amqp==5.3.1
+billiard==4.2.1
+celery==5.4.0
 certifi==2024.7.4
 chardet==3.0.4
 click==8.1.7
-python-dateutil==2.8.1
+python-dateutil==2.9.0
 faker==14.2.1
 filelock==3.13.4
 Flask==2.2.5
@@ -17,8 +17,8 @@ idna==3.7
 importlib-metadata==3.6.0
 itsdangerous==2.0.1
 jinja2==3.1.6
-kombu==5.2.2
-lxml==4.9.1
+kombu==5.3.7
+lxml==5.3.2
 MarkupSafe==2.1.1
 metsrw==0.3.22
 natsort==8.4.0
@@ -28,10 +28,10 @@ plotly-express==0.4.1
 PyMySQL==1.1.1
 pytz==2020.1
 requests==2.32.2
-six==1.14.0
+six==1.16.0
 SQLAlchemy==1.3.15
 urllib3==1.26.19
-vine==5.0.0
+vine==5.1.0
 Werkzeug== 3.0.6
 WTForms==2.3.3
 zipp==3.19.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310}, linting
+envlist = py{39,310,311,312}, linting
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Python 3.8's EOL was 2024-10-07. Removed and added Python 3.11 and 3.12 support making Python support the same as Archivematica's.

https://devguide.python.org/versions/

Also removed use of distutils module, depricated in Python 3.10.