### PR TITLE
Lessen display of deleted storage services (#379)

### DIFF
--- a/AIPscan/Aggregator/templates/result_message.html
+++ b/AIPscan/Aggregator/templates/result_message.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="text-center align-middle" style="margin-top: 15%">
+  <p>{{ message }}</p>
+</div>
+{% endblock %}

--- a/AIPscan/Aggregator/tests/test_views.py
+++ b/AIPscan/Aggregator/tests/test_views.py
@@ -68,7 +68,7 @@ def test_delete_storage_service(app_with_populated_files, mocker):
 
         # Deletion should be attempted if the storage service exists
         response = test_client.get("/aggregator/delete_storage_service/1?confirm=1")
-        assert response.status_code == 302
+        assert response.status_code == 200
 
 
 def test_delete_fetch_job(app_with_populated_files, mocker):

--- a/AIPscan/Aggregator/views.py
+++ b/AIPscan/Aggregator/views.py
@@ -186,8 +186,11 @@ def delete_storage_service(storage_service_id):
 
     tasks.delete_storage_service.delay(storage_service_id)
 
-    flash("Storage service '{}' is being deleted".format(storage_service.name))
-    return redirect(url_for("aggregator.storage_services"))
+    return render_template(
+        "result_message.html",
+        title="Storage Service",
+        message="Storage service '{}' is being deleted".format(storage_service.name),
+    )
 
 
 @aggregator.route("/new_fetch_job/<fetch_job_id>", methods=["POST"])


### PR DESCRIPTION
When a storage service was deleted by a user the response page would, because the deletion takes place asynchronously, show the storage service in the list of storage services. Changed the behavior to not redirect immediately back to the list of storage services.