### PR TITLE
Ensure cleanup of SQLAlchemy sessions in Celery workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ celerytasks.db
 AIPscan/Aggregator/downloads/
 AIPscan/static/dist/
 
+/.env
 [.]venv/
 node_modules/
 .tox/

--- a/AIPscan/Aggregator/celery_helpers.py
+++ b/AIPscan/Aggregator/celery_helpers.py
@@ -1,5 +1,10 @@
+import logging
+from functools import wraps
+
 from AIPscan import db
 from AIPscan.models import package_tasks
+
+logger = logging.getLogger(__name__)
 
 
 def write_celery_update(package_lists_task, workflow_coordinator):
@@ -10,3 +15,32 @@ def write_celery_update(package_lists_task, workflow_coordinator):
     )
     db.session.add(package_task)
     db.session.commit()
+
+
+def with_db_session(func):
+    """Ensure the scoped session is cleaned up around each call."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        func_name = func.__name__
+        try:
+            return func(*args, **kwargs)
+        except Exception:
+            logger.exception("Unhandled exception in %s", func_name)
+            try:
+                db.session.rollback()
+                logger.debug("Rolled back session after error in %s", func_name)
+            except Exception:
+                logger.exception(
+                    "Failed to rollback session after error in %s", func_name
+                )
+            raise
+        finally:
+            try:
+                db.session.remove()
+            except Exception:
+                logger.exception(
+                    "Failed to dispose session after call to %s", func_name
+                )
+
+    return wrapper

--- a/AIPscan/Aggregator/task_helpers.py
+++ b/AIPscan/Aggregator/task_helpers.py
@@ -142,17 +142,5 @@ def create_numbered_subdirs(timestamp, package_list_number):
     return numbered_subdir
 
 
-def write_mets(http_response, package_uuid, subdir):
-    """Given a http response containing our METS data, create the path
-    we want to store our METS at, and then stream the response into a
-    file.
-    """
-    mets_file = f"METS.{package_uuid}.xml"
-    download_file = os.path.join(subdir, mets_file)
-    with open(download_file, "wb") as file:
-        file.write(http_response.content)
-    return download_file
-
-
 def summarize_fetch_job_results(fetch_job):
     return f"aips: '{fetch_job.total_aips}'; sips: '{fetch_job.total_sips}'; dips: '{fetch_job.total_dips}'; deleted: '{fetch_job.total_deleted_aips}'; replicated: '{fetch_job.total_replicas}'"

--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -9,6 +9,7 @@ from celery.utils.log import get_task_logger
 from AIPscan import db
 from AIPscan import typesense_helpers
 from AIPscan.Aggregator import database_helpers
+from AIPscan.Aggregator.celery_helpers import with_db_session
 from AIPscan.Aggregator.celery_helpers import write_celery_update
 from AIPscan.Aggregator.mets_parse_helpers import METSError
 from AIPscan.Aggregator.mets_parse_helpers import download_mets
@@ -111,6 +112,7 @@ def delete_aip(uuid):
 
 
 @celery.task(bind=True)
+@with_db_session
 def workflow_coordinator(
     self, timestamp, storage_service_id, fetch_job_id, packages_directory
 ):
@@ -179,6 +181,7 @@ def make_request(request_url, request_url_without_api_key):
 
 
 @celery.task(bind=True)
+@with_db_session
 def package_lists_request(self, storage_service_id, timestamp, packages_directory):
     """Request package lists from the storage service. Package lists
     will contain details of the AIPs that we want to download.
@@ -245,6 +248,7 @@ def start_index_task(fetch_job_id):
 
 
 @celery.task()
+@with_db_session
 def index_task(fetch_job_id):
     # Update Typesense index
     typesense_helpers.initialize_index()
@@ -268,6 +272,7 @@ def index_task(fetch_job_id):
 
 
 @celery.task()
+@with_db_session
 def get_mets(
     package_uuid,
     aip_size,
@@ -370,6 +375,7 @@ def get_mets(
 
 
 @celery.task()
+@with_db_session
 def delete_fetch_job(fetch_job_id):
     fetch_job = db.session.get(FetchJob, fetch_job_id)
     if os.path.exists(fetch_job.download_directory):
@@ -379,6 +385,7 @@ def delete_fetch_job(fetch_job_id):
 
 
 @celery.task()
+@with_db_session
 def delete_storage_service(storage_service_id):
     storage_service = db.session.get(StorageService, storage_service_id)
     mets_fetch_jobs = FetchJob.query.filter_by(

--- a/AIPscan/Aggregator/tasks.py
+++ b/AIPscan/Aggregator/tasks.py
@@ -20,7 +20,6 @@ from AIPscan.Aggregator.task_helpers import parse_package_list_file
 from AIPscan.Aggregator.task_helpers import process_package_object
 from AIPscan.Aggregator.task_helpers import summarize_fetch_job_results
 from AIPscan.celery import celery
-from AIPscan.helpers import file_sha256_hash
 from AIPscan.models import AIP
 from AIPscan.models import Agent
 from AIPscan.models import FetchJob
@@ -306,7 +305,7 @@ def get_mets(
 
     # Download METS file
     storage_service = db.session.get(StorageService, storage_service_id)
-    download_file = download_mets(
+    download_file, mets_hash = download_mets(
         storage_service,
         package_uuid,
         relative_path_to_mets,
@@ -314,7 +313,6 @@ def get_mets(
         package_list_no,
     )
     mets_name = os.path.basename(download_file)
-    mets_hash = file_sha256_hash(download_file)
 
     # If METS file's hash matches an existing value, this is a duplicate of an
     # existing AIP and we can safely ignore it.

--- a/AIPscan/Aggregator/tests/test_task_helpers.py
+++ b/AIPscan/Aggregator/tests/test_task_helpers.py
@@ -1,6 +1,5 @@
 import json
 import os
-import uuid
 from datetime import datetime
 
 import pytest
@@ -173,20 +172,6 @@ def test_create_numbered_subdirs(timestamp, package_list_number, result, mocker)
     subdir_string = task_helpers.create_numbered_subdirs(timestamp, package_list_number)
     assert mocked_makedirs.call_count == 0
     assert subdir_string == result
-
-
-def test_write_mets(mocker, tmpdir):
-    """Ensure that METS is written to expected location."""
-    CONTENT = b"test content"
-    http_response = mocker.MagicMock()
-    http_response.content = CONTENT
-    package_uuid = str(uuid.uuid4())
-    expected_path = os.path.join(tmpdir, f"METS.{package_uuid}.xml")
-
-    actual_path = task_helpers.write_mets(http_response, package_uuid, tmpdir)
-    assert expected_path == actual_path
-    with open(actual_path, "rb") as mets_file:
-        assert mets_file.read() == CONTENT
 
 
 @pytest.fixture()

--- a/AIPscan/Aggregator/tests/test_tasks.py
+++ b/AIPscan/Aggregator/tests/test_tasks.py
@@ -68,7 +68,7 @@ def test_get_mets_task(app_instance, tmpdir, mocker, fixture_path, package_uuid)
         timestamp_str,
         package_list_no,
     ):
-        return mets_file
+        return mets_file, test_helpers.file_sha256_hash(mets_file)
 
     mocker.patch("AIPscan.Aggregator.tasks.download_mets", mock_download_mets)
     delete_mets_file = mocker.patch("AIPscan.Aggregator.tasks.os.remove")

--- a/AIPscan/test_helpers.py
+++ b/AIPscan/test_helpers.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import time
@@ -21,6 +22,12 @@ from AIPscan.models import StorageService
 from AIPscan.models import index_tasks
 
 TEST_SHA_256 = "79c16fa9573ec46c5f60fd54b34f314159e0623ca53d8d2f00c5875dbb4e0dfd"
+
+
+def file_sha256_hash(filepath):
+    """Return SHA256 hash for contents of file."""
+    with open(filepath, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
 
 
 def _add_test_object_to_db(test_object):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,8 +58,6 @@ services:
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
       - rabbitmq_logs:/var/log/rabbitmq
-    depends_on:
-      - aipscan
     healthcheck:
        test: rabbitmq-diagnostics -q ping
        interval: 30s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,8 +81,6 @@ services:
          condition: service_healthy
       rabbitmq:
          condition: service_healthy
-      aipscan:
-         condition: service_healthy
 
   typesense:
     image: typesense/typesense:29.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,7 @@ services:
     command: gunicorn --preload --timeout 10 --workers 1 --error-logfile - --log-level debug --capture-output --bind 0.0.0.0:5000 "AIPscan:create_app()"
     volumes:
       - "./:/app:rw"
-    deploy:
-      restart_policy:
-        condition: on-failure
+    restart: on-failure
     healthcheck:
       test: ["CMD", "python", "-c", "import requests; requests.get('http://localhost:5000', timeout=3).raise_for_status()"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
 
   rabbitmq:
     image: rabbitmq:4.1.4-management
-    container_name: 'rabbitmq'
     ports:
       - 5672:5672
       - 15672:15672

--- a/tools/fetch_aips
+++ b/tools/fetch_aips
@@ -13,8 +13,8 @@ from helpers import fetch
 from AIPscan import db
 from AIPscan.Aggregator import database_helpers
 from AIPscan.Aggregator.task_helpers import create_numbered_subdirs
-from AIPscan.Aggregator.task_helpers import process_packages
 from AIPscan.Aggregator.task_helpers import summarize_fetch_job_results
+from AIPscan.Aggregator.tasks import process_packages
 from AIPscan.config import CONFIGS
 from AIPscan.models import StorageService
 


### PR DESCRIPTION
A customer has reported intermittent crashes where the aggregator’s Celery workers lose their MySQL connection: once a task fails mid-commit, every subsequent task in that worker keeps dying with “command out of sync” errors because the session stays broken. I'm hoping these changes will help keep workers healthy to continue working on the rest of the tasks queued, while we keep investigating the underlying issue (server logs not available yet).